### PR TITLE
MediaQueue: Added tiggers and started off with unit-tests

### DIFF
--- a/MediaManager.sln
+++ b/MediaManager.sln
@@ -27,6 +27,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.MediaManager.tvOS", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.MediaManager.MacOS", "MediaManager\Plugin.MediaManager.MacOS\Plugin.MediaManager.MacOS.csproj", "{7ED0F28D-8838-4E24-9FA9-E3FA0B5649BF}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{8F27E303-813D-4DBC-955D-89469A5E7B8D}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Plugin.MediaManager.Abstraction", "Plugin.MediaManager.Abstraction\Plugin.MediaManager.Abstraction.csproj", "{0E7E2F98-F621-44FE-91C3-D554749F4628}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -309,6 +313,30 @@ Global
 		{7ED0F28D-8838-4E24-9FA9-E3FA0B5649BF}.Release|x64.Build.0 = Release|Any CPU
 		{7ED0F28D-8838-4E24-9FA9-E3FA0B5649BF}.Release|x86.ActiveCfg = Release|Any CPU
 		{7ED0F28D-8838-4E24-9FA9-E3FA0B5649BF}.Release|x86.Build.0 = Release|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Debug|ARM.Build.0 = Debug|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Debug|iPhone.ActiveCfg = Debug|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Debug|iPhone.Build.0 = Debug|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Debug|iPhoneSimulator.ActiveCfg = Debug|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Debug|iPhoneSimulator.Build.0 = Debug|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Debug|x64.Build.0 = Debug|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Debug|x86.Build.0 = Debug|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Release|ARM.ActiveCfg = Release|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Release|ARM.Build.0 = Release|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Release|iPhone.ActiveCfg = Release|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Release|iPhone.Build.0 = Release|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Release|x64.ActiveCfg = Release|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Release|x64.Build.0 = Release|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Release|x86.ActiveCfg = Release|Any CPU
+		{0E7E2F98-F621-44FE-91C3-D554749F4628}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -318,5 +346,6 @@ Global
 		{C2E58BB1-3F2F-40C8-BD3F-38B210E54560} = {E30B6663-E909-40F4-AE0B-6A8D08BCA39F}
 		{BC83287D-8247-4033-A946-B8C547A7F534} = {E30B6663-E909-40F4-AE0B-6A8D08BCA39F}
 		{19955052-96FC-4149-84DD-C95A4C846C87} = {E30B6663-E909-40F4-AE0B-6A8D08BCA39F}
+		{0E7E2F98-F621-44FE-91C3-D554749F4628} = {8F27E303-813D-4DBC-955D-89469A5E7B8D}
 	EndGlobalSection
 EndGlobal

--- a/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
@@ -14,6 +14,13 @@ namespace Plugin.MediaManager.Abstractions
         public MediaQueue ()
         {
             _queue = new ObservableCollection<IMediaFile>();
+
+            _queue.CollectionChanged += (sender, e) =>
+            {
+                if (CollectionChanged != null)
+                    CollectionChanged(sender, e);
+            };
+
             RegisterCountTriggers();
             RegisterCurrentTriggers();
         }

--- a/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
@@ -144,7 +144,12 @@ namespace Plugin.MediaManager.Abstractions
         {
             Index = -1;
             _queue.Clear();
-            _unshuffledQueue = null;
+
+            if (_unshuffledQueue != null)
+            {
+                _unshuffledQueue = null;
+                OnPropertyChanged(nameof(Shuffle));
+            }
         }
 
         public bool Contains(IMediaFile item)

--- a/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
@@ -260,13 +260,11 @@ namespace Plugin.MediaManager.Abstractions
                     elements.RemoveAt(Index);
                 }
 
+				var random = new Random();
                 for (var i = elements.Count - 1; i > 1; i--)
                 {
                     // Get a random index
-                    //var swapIndex = Math.Abs((int)WinRTCrypto.CryptographicBuffer.GenerateRandomNumber()) % (i + 1);
-
-                    var random = new Random((int)DateTime.Now.Ticks);
-                    var swapIndex = random.Next(0, i + 1);
+					var swapIndex = random.Next(0, i + 1);
 
                     var tmp = elements[i];
                     elements[i] = elements[swapIndex];

--- a/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
@@ -25,9 +25,9 @@ namespace Plugin.MediaManager.Abstractions
             RegisterCurrentTriggers();
         }
 
-        private ObservableCollection<IMediaFile> _queue;
+		protected ObservableCollection<IMediaFile> _queue { get; private set; }
 
-        private ObservableCollection<IMediaFile> _unshuffledQueue;
+		protected ObservableCollection<IMediaFile> _unshuffledQueue;
 
         private int _count;
         public int Count
@@ -308,7 +308,7 @@ namespace Plugin.MediaManager.Abstractions
             OnPropertyChanged(nameof(Shuffle));
         }
 
-        private void ReplaceQueueWith(IEnumerable<IMediaFile> files)
+		protected void ReplaceQueueWith(IEnumerable<IMediaFile> files)
         {
             CollectionChangedEventDisabled = true;
             _queue.Clear();

--- a/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
@@ -25,9 +25,9 @@ namespace Plugin.MediaManager.Abstractions
             RegisterCurrentTriggers();
         }
 
-		protected ObservableCollection<IMediaFile> _queue { get; private set; }
+        protected ObservableCollection<IMediaFile> _queue { get; private set; }
 
-		protected ObservableCollection<IMediaFile> _unshuffledQueue;
+        protected ObservableCollection<IMediaFile> _unshuffledQueue;
 
         private int _count;
         public int Count
@@ -266,11 +266,11 @@ namespace Plugin.MediaManager.Abstractions
                     elements.RemoveAt(Index);
                 }
 
-				var random = new Random();
+                var random = new Random();
                 for (var i = elements.Count - 1; i > 1; i--)
                 {
                     // Get a random index
-					var swapIndex = random.Next(0, i + 1);
+                    var swapIndex = random.Next(0, i + 1);
 
                     var tmp = elements[i];
                     elements[i] = elements[swapIndex];
@@ -308,7 +308,7 @@ namespace Plugin.MediaManager.Abstractions
             OnPropertyChanged(nameof(Shuffle));
         }
 
-		protected void ReplaceQueueWith(IEnumerable<IMediaFile> files)
+        protected void ReplaceQueueWith(IEnumerable<IMediaFile> files)
         {
             CollectionChangedEventDisabled = true;
             _queue.Clear();

--- a/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
@@ -15,6 +15,7 @@ namespace Plugin.MediaManager.Abstractions
         {
             _queue = new ObservableCollection<IMediaFile>();
             RegisterCountTriggers();
+            RegisterCurrentTriggers();
         }
 
         private ObservableCollection<IMediaFile> _queue;
@@ -304,6 +305,42 @@ namespace Plugin.MediaManager.Abstractions
             };
 
             _count = _queue.Count;
+        }
+
+        private void RegisterCurrentTriggers()
+        {
+            var updateProperty = new Action(() =>
+                {
+                    IMediaFile current = null;
+                    if (Count - 1 >= Index && Index >= 0)
+                    {
+                        current = _queue[Index];
+                    }
+
+                    if (_current != current)
+                    {
+                        _current = current;
+						OnPropertyChanged(nameof(Current));
+                    }
+                });
+
+            PropertyChanged += (sender, e) =>
+            {
+                if (e.PropertyName == nameof(Index))
+                {
+                    updateProperty();
+                }
+            };
+
+            _queue.CollectionChanged += (sender, e) =>
+            {
+                updateProperty();
+            };
+
+            if (Count - 1 >= Index && Index >= 0)
+            {
+                _current = _queue[Index];
+            }
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
@@ -96,18 +96,23 @@ namespace Plugin.MediaManager.Abstractions
             }
         }
 
+        /// <summary>
+        /// Occurs when the collection changes.
+        /// </summary>
         public event NotifyCollectionChangedEventHandler CollectionChanged;
 
         private bool CollectionChangedEventDisabled;
 
+        /// <summary>
+        /// Occurs when a property value changes.
+        /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
 
         protected void OnPropertyChanged(string name)
         {
-            PropertyChangedEventHandler handler = PropertyChanged;
-            if (handler != null)
+            if (PropertyChanged != null)
             {
-                handler(this, new PropertyChangedEventArgs(name));
+                PropertyChanged(this, new PropertyChangedEventArgs(name));
             }
         }
 
@@ -239,6 +244,7 @@ namespace Plugin.MediaManager.Abstractions
         }
 
         private CancellationTokenSource shuffleCancellation = new CancellationTokenSource();
+
         public void ToggleShuffle()
         {
             if (!Shuffle)
@@ -341,7 +347,7 @@ namespace Plugin.MediaManager.Abstractions
                     if (_current != current)
                     {
                         _current = current;
-						OnPropertyChanged(nameof(Current));
+                        OnPropertyChanged(nameof(Current));
                     }
                 });
 

--- a/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/MediaQueue.cs
@@ -14,17 +14,19 @@ namespace Plugin.MediaManager.Abstractions
         public MediaQueue ()
         {
             _queue = new ObservableCollection<IMediaFile>();
+            RegisterCountTriggers();
         }
 
         private ObservableCollection<IMediaFile> _queue;
 
         private ObservableCollection<IMediaFile> _unshuffledQueue;
 
+        private int _count;
         public int Count
         {
             get
             {
-                return _unshuffledQueue?.Count ?? _queue?.Count ?? 0;
+                return _count;
             }
         }
 
@@ -286,6 +288,22 @@ namespace Plugin.MediaManager.Abstractions
                 _unshuffledQueue = null;
             }
             OnPropertyChanged(nameof(Shuffle));
+        }
+
+        private void RegisterCountTriggers()
+        {
+            _queue.CollectionChanged += (sender, e) =>
+            {
+                var count = _queue.Count;
+
+                if (_count != count)
+                {
+                    _count = count;
+                    OnPropertyChanged(nameof(Count));
+                }
+            };
+
+            _count = _queue.Count;
         }
 
         IEnumerator IEnumerable.GetEnumerator()

--- a/Plugin.MediaManager.Abstraction/MediaFile.cs
+++ b/Plugin.MediaManager.Abstraction/MediaFile.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using Plugin.MediaManager.Abstractions;
+
+namespace Plugin.MediaManager.Abstraction
+{
+    class MediaFile : IMediaFile
+    {
+        public int Id { get; set; }
+        public MediaFileType Type { get; set; }
+        public string Url { get; set; }
+
+        public override string ToString()
+        {
+            return string.Format("[MediaFile: Id={0}, Type={1}, Url={2}]", Id, Type, Url);
+        }
+    }
+}

--- a/Plugin.MediaManager.Abstraction/Plugin.MediaManager.Abstraction.csproj
+++ b/Plugin.MediaManager.Abstraction/Plugin.MediaManager.Abstraction.csproj
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0E7E2F98-F621-44FE-91C3-D554749F4628}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>Plugin.MediaManager.Abstraction</RootNamespace>
+    <AssemblyName>Plugin.MediaManager.Abstraction</AssemblyName>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="nunit.framework">
+      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Tests\MediaQueueTests.cs" />
+    <Compile Include="MediaFile.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Tests\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MediaManager\Plugin.MediaManager.Abstractions\Plugin.MediaManager.Abstractions.csproj">
+      <Project>{6EDB0588-FFC5-4EF5-8A99-9E241D0F878D}</Project>
+      <Name>Plugin.MediaManager.Abstractions</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/Plugin.MediaManager.Abstraction/Tests/MediaQueueTests.cs
+++ b/Plugin.MediaManager.Abstraction/Tests/MediaQueueTests.cs
@@ -1,0 +1,334 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Linq;
+using NUnit.Framework;
+using Plugin.MediaManager.Abstractions;
+
+namespace Plugin.MediaManager.Abstraction.Tests
+{
+    [TestFixture]
+    public class MediaQueueTests
+    {
+        /// <summary>
+        /// Checking the initial setup of an instance.
+        /// </summary>
+        [Test]
+        public void Initialization()
+        {
+            var queue = new MediaQueue();
+
+            Assert.AreEqual(0, queue.Count);
+            Assert.AreEqual(null, queue.Current);
+            Assert.AreEqual(-1, queue.Index);
+            Assert.AreEqual(false, queue.Repeat);
+            Assert.AreEqual(false, queue.Shuffle);
+        }
+
+        [TestFixture]
+        private class Add
+        {
+            /// <summary>
+            /// Checks adding an item, including all it's triggers.
+            /// </summary>
+            [Test]
+            public void Basic()
+            {
+                var queue = new MediaQueue();
+
+                IList<NotifyCollectionChangedEventArgs> collectionChangedEvents = new List<NotifyCollectionChangedEventArgs>();
+                IList<PropertyChangedEventArgs> propertyChangedEvents = new List<PropertyChangedEventArgs>();
+
+                queue.CollectionChanged += (sender, e) => collectionChangedEvents.Add(e);
+                queue.PropertyChanged += (sender, e) => propertyChangedEvents.Add(e);
+
+                var tracks = new[]
+                    {
+                        new MediaFile() { Id = 1 },
+                        new MediaFile() { Id = 2 },
+                    };
+
+                queue.Add(tracks[0]);
+
+                Assert.AreEqual(1, queue.Count);
+                Assert.AreEqual(tracks[0], queue.Current);
+                Assert.AreEqual(0, queue.Index);
+                Assert.AreEqual(false, queue.Repeat);
+                Assert.AreEqual(false, queue.Shuffle);
+
+                Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
+                Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
+                Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Count").Count());
+                Assert.AreEqual(3, propertyChangedEvents.Count);
+                Assert.AreEqual(1, collectionChangedEvents.Where(e => e.NewItems.Count == 1 && e.OldItems == null).Count());
+                Assert.AreEqual(1, collectionChangedEvents.Count);
+
+                queue.Add(tracks[1]);
+
+                Assert.AreEqual(2, queue.Count);
+                Assert.AreEqual(tracks[0], queue.Current);
+                Assert.AreEqual(0, queue.Index);
+                Assert.AreEqual(false, queue.Repeat);
+                Assert.AreEqual(false, queue.Shuffle);
+
+                Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
+                Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
+                Assert.AreEqual(2, propertyChangedEvents.Where(e => e.PropertyName == "Count").Count());
+                Assert.AreEqual(4, propertyChangedEvents.Count);
+                Assert.AreEqual(2, collectionChangedEvents.Where(e => e.NewItems.Count == 1 && e.OldItems == null).Count());
+                Assert.AreEqual(2, collectionChangedEvents.Count);
+            }
+        }
+
+        [TestFixture]
+        private class Clear
+        {
+            /// <summary>
+            /// Verify that clearing a view calls all the necessary triggers
+            /// </summary>
+            [Test]
+            public void Basic()
+            {
+                var queue = new MediaQueue();
+
+                var tracks = new[]
+                    {
+                        new MediaFile() { Id = 1 },
+                        new MediaFile() { Id = 2 },
+                    };
+
+                queue.AddRange(tracks);
+
+                IList<NotifyCollectionChangedEventArgs> collectionChangedEvents = new List<NotifyCollectionChangedEventArgs>();
+                IList<PropertyChangedEventArgs> propertyChangedEvents = new List<PropertyChangedEventArgs>();
+
+                queue.CollectionChanged += (sender, e) => collectionChangedEvents.Add(e);
+                queue.PropertyChanged += (sender, e) => propertyChangedEvents.Add(e);
+
+                queue.Clear();
+
+                Assert.AreEqual(0, queue.Count);
+                Assert.AreEqual(null, queue.Current);
+                Assert.AreEqual(-1, queue.Index);
+                Assert.AreEqual(false, queue.Repeat);
+                Assert.AreEqual(false, queue.Shuffle);
+
+                Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
+                Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
+                Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Count").Count());
+                Assert.AreEqual(3, propertyChangedEvents.Count);
+                Assert.AreEqual(1, collectionChangedEvents.Where(e => e.NewItems == null && e.OldItems == null).Count());
+                Assert.AreEqual(1, collectionChangedEvents.Count);
+            }
+
+            /// <summary>
+            /// Verify that Shuffle is reset after clearing the queue and that Repeat property is left untouched.
+            /// </summary>
+            [Test]
+            public void ShuffledAndRepeated()
+            {
+                var queue = new MediaQueue();
+
+                var tracks = new[]
+                    {
+                        new MediaFile() { Id = 1 },
+                        new MediaFile() { Id = 2 },
+                    };
+
+                queue.AddRange(tracks);
+                queue.ToggleShuffle();
+                queue.ToggleRepeat();
+
+                IList<NotifyCollectionChangedEventArgs> collectionChangedEvents = new List<NotifyCollectionChangedEventArgs>();
+                IList<PropertyChangedEventArgs> propertyChangedEvents = new List<PropertyChangedEventArgs>();
+
+                queue.CollectionChanged += (sender, e) => collectionChangedEvents.Add(e);
+                queue.PropertyChanged += (sender, e) => propertyChangedEvents.Add(e);
+
+                queue.Clear();
+
+                Assert.AreEqual(0, queue.Count);
+                Assert.AreEqual(null, queue.Current);
+                Assert.AreEqual(-1, queue.Index);
+                Assert.AreEqual(true, queue.Repeat);
+                Assert.AreEqual(false, queue.Shuffle);
+
+                Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
+                Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
+                Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Count").Count());
+                Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Shuffle").Count());
+                Assert.AreEqual(4, propertyChangedEvents.Count);
+                Assert.AreEqual(1, collectionChangedEvents.Where(e => e.NewItems == null && e.OldItems == null).Count());
+                Assert.AreEqual(1, collectionChangedEvents.Count);
+            }
+        }
+
+        [TestFixture]
+        private class ToggleShuffle
+        {
+            [Test]
+            public void WhenShufflingWorks_OrderIsRandomized()
+            {
+                var arr = new[]
+                              {
+                                  new MediaFile() {Id = 1},
+                                  new MediaFile() {Id = 2},
+                                  new MediaFile() {Id = 3},
+                                  new MediaFile() {Id = 4},
+                                  new MediaFile() {Id = 5},
+                                  new MediaFile() {Id = 6},
+                                  new MediaFile() {Id = 7},
+                                  new MediaFile() {Id = 8},
+                                  new MediaFile() {Id = 9},
+                                  new MediaFile() {Id = 10},
+                                  new MediaFile() {Id = 11}
+                              };
+
+                Console.WriteLine("Original: {0}", string.Join(",", arr.Select(x => x.Id)));
+
+                var queue = new MediaQueue();
+                Console.WriteLine("Current Index: {0}", queue.Index);
+                queue.AddRange(arr);
+
+                queue.ToggleShuffle();
+
+                Console.WriteLine("Result: {0}", string.Join(",", queue.Cast<MediaFile>().Select(x => x.Id)));
+
+                CollectionAssert.AllItemsAreUnique(queue.Cast<MediaFile>().Select(x => x.Id));
+                CollectionAssert.AreEquivalent(queue.Cast<MediaFile>().Select(x => x.Id), arr.Select(x => x.Id));
+                Assert.That(queue.Cast<MediaFile>().Select(x => x.Id), Is.Not.Ordered);
+                Assert.AreEqual(arr[queue.Index].Id, queue.Cast<MediaFile>().ElementAt(queue.Index).Id, "The current item has been moved");
+                Assert.AreEqual(arr.Length, queue.Count, "The array length is different");
+            }
+
+            [Test]
+            public void WhenUnshufflingWorks_OrderIsSameAsBefore()
+            {
+                var arr = new[]
+                              {
+                                  new MediaFile() {Id = 1},
+                                  new MediaFile() {Id = 2},
+                                  new MediaFile() {Id = 3},
+                                  new MediaFile() {Id = 4},
+                                  new MediaFile() {Id = 5},
+                                  new MediaFile() {Id = 6},
+                                  new MediaFile() {Id = 7},
+                                  new MediaFile() {Id = 8},
+                                  new MediaFile() {Id = 9},
+                                  new MediaFile() {Id = 10},
+                                  new MediaFile() {Id = 11}
+                              };
+
+                Console.WriteLine("Original: {0}", string.Join(",", arr.Select(x => x.Id)));
+
+                var queue = new MediaQueue();
+                Console.WriteLine("Current Index: {0}", queue.Index);
+                queue.AddRange(arr);
+
+                queue.ToggleShuffle();
+
+                Console.WriteLine("Shuffled: {0}", string.Join(",", queue.Cast<MediaFile>().Select(x => x.Id)));
+
+                queue.ToggleShuffle();
+
+                Console.WriteLine("Unshuffled: {0}", string.Join(",", queue.Cast<MediaFile>().Select(x => x.Id)));
+
+                CollectionAssert.AllItemsAreUnique(queue.Cast<MediaFile>().Select(x => x.Id));
+                CollectionAssert.AreEqual(queue.Cast<MediaFile>().Select(x => x.Id), arr.Cast<MediaFile>().Select(x => x.Id));
+                Assert.AreEqual(arr[queue.Index].Id, queue.Cast<MediaFile>().ElementAt(queue.Index).Id, "The current item has been moved");
+                Assert.AreEqual(arr.Length, queue.Count, "The array length is different");
+            }
+
+            [Test]
+            public void WhenAddingItemsWhileShuffled_OrderIsSameAsBeforeButWithExtraItem()
+            {
+                var arr = new[]
+                              {
+                                  new MediaFile() {Id = 1},
+                                  new MediaFile() {Id = 2},
+                                  new MediaFile() {Id = 3},
+                                  new MediaFile() {Id = 4},
+                                  new MediaFile() {Id = 5},
+                                  new MediaFile() {Id = 6},
+                                  new MediaFile() {Id = 7},
+                                  new MediaFile() {Id = 8},
+                                  new MediaFile() {Id = 9},
+                                  new MediaFile() {Id = 10},
+                                  new MediaFile() {Id = 11}
+                              };
+
+                Console.WriteLine("Original: {0}", string.Join(",", arr.Select(x => x.Id)));
+
+                var queue = new MediaQueue();
+                Console.WriteLine("Current Index: {0}", queue.Index);
+                queue.AddRange(arr);
+
+                queue.ToggleShuffle();
+                queue.Add(new MediaFile() { Id = 99 });
+
+                Console.WriteLine("Shuffled: {0}", string.Join(",", queue.Cast<MediaFile>().Select(x => x.Id)));
+
+                queue.ToggleShuffle();
+
+                Console.WriteLine("Unshuffled: {0}", string.Join(",", queue.Cast<MediaFile>().Select(x => x.Id)));
+
+                CollectionAssert.AllItemsAreUnique(queue.Cast<MediaFile>().Select(x => x.Id));
+                Assert.AreEqual(arr[0].Id, queue.Cast<MediaFile>().ElementAt(0).Id);
+                Assert.AreEqual(arr[1].Id, queue.Cast<MediaFile>().ElementAt(1).Id);
+                Assert.AreEqual(arr[2].Id, queue.Cast<MediaFile>().ElementAt(2).Id);
+                Assert.AreEqual(arr[3].Id, queue.Cast<MediaFile>().ElementAt(3).Id);
+                Assert.AreEqual(arr[4].Id, queue.Cast<MediaFile>().ElementAt(4).Id);
+                Assert.AreEqual(arr[5].Id, queue.Cast<MediaFile>().ElementAt(5).Id);
+                Assert.AreEqual(arr[6].Id, queue.Cast<MediaFile>().ElementAt(6).Id);
+                Assert.AreEqual(arr[7].Id, queue.Cast<MediaFile>().ElementAt(7).Id);
+                Assert.AreEqual(arr[8].Id, queue.Cast<MediaFile>().ElementAt(8).Id);
+                Assert.AreEqual(arr[9].Id, queue.Cast<MediaFile>().ElementAt(9).Id);
+                Assert.AreEqual(arr[10].Id, queue.Cast<MediaFile>().ElementAt(10).Id);
+                Assert.AreEqual(99, queue.Cast<MediaFile>().Last().Id);
+                Assert.AreEqual(arr.Length + 1, queue.Count, "The array length is different");
+            }
+
+            [Test]
+            public void ShuffleTwice_WhenRandomNumberGeneratorWorks_OrderIsDifferent()
+            {
+                var arr = new[]
+                              {
+                                  new MediaFile() {Id = 1},
+                                  new MediaFile() {Id = 2},
+                                  new MediaFile() {Id = 3},
+                                  new MediaFile() {Id = 4},
+                                  new MediaFile() {Id = 5},
+                                  new MediaFile() {Id = 6},
+                                  new MediaFile() {Id = 7},
+                                  new MediaFile() {Id = 8},
+                                  new MediaFile() {Id = 9},
+                                  new MediaFile() {Id = 10},
+                                  new MediaFile() {Id = 11}
+                              };
+
+                Console.WriteLine("Original: {0}", string.Join(",", arr.Select(x => x.Id)));
+
+                var queue1 = new MediaQueue();
+                queue1.AddRange(arr);
+
+                var queue2 = new MediaQueue();
+                queue2.AddRange(arr);
+
+                // Randomize in quick succession to prove that the result is not the same
+                // Using Random() here would create two equal lists, hence the use of PCLCrypto.
+                queue1.ToggleShuffle();
+                queue2.ToggleShuffle();
+
+                Console.WriteLine("Queue1: {0}", string.Join(",", queue1.Cast<MediaFile>().Select(x => x.Id)));
+                Console.WriteLine("Queue2: {0}", string.Join(",", queue2.Cast<MediaFile>().Select(x => x.Id)));
+
+                CollectionAssert.AllItemsAreUnique(queue1.Cast<MediaFile>().Select(x => x.Id));
+                CollectionAssert.AllItemsAreUnique(queue2.Cast<MediaFile>().Select(x => x.Id));
+                CollectionAssert.AreNotEqual(queue1.Cast<MediaFile>().Select(x => x.Id), queue2.Cast<MediaFile>().Select(x => x.Id));
+                Assert.AreEqual(arr[queue1.Index].Id, queue1.Cast<MediaFile>().ElementAt(queue1.Index).Id, "The current item has been moved");
+                Assert.AreEqual(arr[queue2.Index].Id, queue2.Cast<MediaFile>().ElementAt(queue2.Index).Id, "The current item has been moved");
+            }
+        }
+    }
+}

--- a/Plugin.MediaManager.Abstraction/packages.config
+++ b/Plugin.MediaManager.Abstraction/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
I did quite some changes to the MediaQueue, packed with this implemenation.

I've just added a property-changed event when `Count` or `Current`, forwarded the internal queue changes (before the `CollectionChanged` event never got triggered), fixed the randomness of the shuffle-method (according to http://stackoverflow.com/questions/767999/random-number-generator-only-generating-one-random-number#answer-768001) and started off with unit-tests - mainly for the MediaQueue implementation.