### PR TITLE
Android: Updated MediaPlayerService.OnError and MediaSessionManager.UpdatePlaybackState

### DIFF
--- a/MediaManager/Plugin.MediaManager.Android/MediaPlayerService/MediaPlayerService.cs
+++ b/MediaManager/Plugin.MediaManager.Android/MediaPlayerService/MediaPlayerService.cs
@@ -234,7 +234,7 @@ namespace Plugin.MediaManager
 
         public bool OnError(MediaPlayer mp, MediaError what, int extra)
         {
-            SessionManager.UpdatePlaybackState(PlaybackStateCompat.StateError, Position.Seconds);
+            SessionManager.UpdatePlaybackState(PlaybackStateCompat.StateError, Position.Seconds, Enum.GetName(typeof(MediaError),what));
             Stop();
             return true;
         }

--- a/MediaManager/Plugin.MediaManager.Android/MediaSession/MediaSessionManager.cs
+++ b/MediaManager/Plugin.MediaManager.Android/MediaSession/MediaSessionManager.cs
@@ -87,7 +87,7 @@ namespace Plugin.MediaManager.MediaSession
         /// </summary>
         /// <param name="state">The state.</param>
         /// <param name="position"></param>
-        public void UpdatePlaybackState(int state, int position = 0)
+        public void UpdatePlaybackState(int state, int position = 0, string errorMessage = "")
         {
             if(CurrentSession == null && (_binder?.IsBinderAlive).GetValueOrDefault(false) && !string.IsNullOrWhiteSpace(_packageName))
                 InitMediaSession(_packageName, _binder);
@@ -101,6 +101,8 @@ namespace Plugin.MediaManager.MediaSession
                         | PlaybackStateCompat.ActionStop);
 
             stateBuilder.SetState(state, position, 0, SystemClock.ElapsedRealtime());
+            if (state == PlaybackStateCompat.StateError)
+                stateBuilder.SetErrorMessage(errorMessage);
             CurrentSession?.SetPlaybackState(stateBuilder.Build());
             OnStatusChanged?.Invoke(CurrentSession, state);
 


### PR DESCRIPTION
Updated MediaPlayerService.OnError and MediaSessionManager.UpdatePlaybackState so that if it's updating the state to StateError, it can pass an error message, which the documentation for PlaybackStateCompat.Builder says should be set.