### PR TITLE
Changed MediaManagerImplementation so that when Pause action is recei…

### DIFF
--- a/MediaManager/Plugin.MediaManager.Android/Audio/AudioPlayerBase.cs
+++ b/MediaManager/Plugin.MediaManager.Android/Audio/AudioPlayerBase.cs
@@ -178,7 +178,17 @@ namespace Plugin.MediaManager
 
         private void CancelPlayingHandler()
         {
-            if (_onPlayingCancellationSource.Token.CanBeCanceled)
+            bool canBeCancelled;
+            try
+            {
+                canBeCancelled = _onPlayingCancellationSource.Token.CanBeCanceled;
+            }
+            catch (ObjectDisposedException)
+            {
+                canBeCancelled = false;
+            }
+
+            if (canBeCancelled)
             {
                 _onPlayingCancellationSource.Cancel();
                 _onPlayingCancellationSource.Dispose();

--- a/MediaManager/Plugin.MediaManager.Android/MediaManagerImplementation.cs
+++ b/MediaManager/Plugin.MediaManager.Android/MediaManagerImplementation.cs
@@ -42,9 +42,13 @@ namespace Plugin.MediaManager
 
         private async void HandleNotificationActions(object sender, string action)
         {
-            if (action.Equals(MediaServiceBase.ActionPlay) || action.Equals(MediaServiceBase.ActionPause))
+            if (action.Equals(MediaServiceBase.ActionPlay))
             {
                 await PlayPause();
+            }
+            else if (action.Equals(MediaServiceBase.ActionPause))
+            {
+                await Pause();
             }
             else if (action.Equals(MediaServiceBase.ActionPrevious))
             {


### PR DESCRIPTION
…ved, it calls Pause() instead of PlayPause() which could cause the media to start playing again if it was already paused.
This is to fix an issue where if the media is paused, and you remove headphones or turn off bluetooth device, it would start playing again.