### PR TITLE
A couple Android fixes

### DIFF
--- a/MediaManager/Plugin.MediaManager.Android/Environment.txt
+++ b/MediaManager/Plugin.MediaManager.Android/Environment.txt
@@ -1,0 +1,1 @@
+﻿MONO_GC_PARAMS=bridge-implementation=old

--- a/MediaManager/Plugin.MediaManager.Android/Plugin.MediaManager.Android.csproj
+++ b/MediaManager/Plugin.MediaManager.Android/Plugin.MediaManager.Android.csproj
@@ -14,7 +14,8 @@
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
     <AndroidUseLatestPlatformSdk>False</AndroidUseLatestPlatformSdk>
     <TargetFrameworkVersion>v7.0</TargetFrameworkVersion>
-    <AndroidTlsProvider></AndroidTlsProvider>
+    <AndroidTlsProvider>
+    </AndroidTlsProvider>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -87,6 +88,9 @@
       <Project>{6edb0588-ffc5-4ef5-8a99-9e241d0f878d}</Project>
       <Name>Plugin.MediaManager.Abstractions</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidEnvironment Include="Environment.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 


### PR DESCRIPTION
1) Removed exception thrown by MediaManagerBase.CurrentPlaybackManager getter, and allowed it to return null instead. Added null reference checks to code that accessed getter. #76 

2) Modified MediaPlayerService.Play() so that if there is an IllegalStateException thrown by _mediaPlayer.PrepareAsync(), it retries several times.

3) Modified MediaPlayerService.SetMediaPlayerDataSource() to avoid some exceptions.

4) Fixed #87 