### PR TITLE
IMediaQueue Shuffle rename to IsShuffled

### DIFF
--- a/MediaManager/Plugin.MediaManager.Abstractions/IMediaQueue.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/IMediaQueue.cs
@@ -36,7 +36,7 @@ namespace Plugin.MediaManager.Abstractions
         RepeatType Repeat { get; set; }
 
         /// <summary>
-        /// Activates or deactivates the Shuffle option
+        /// Wether the queue is shuffled
         /// </summary>
         bool IsShuffled { get; }
 

--- a/MediaManager/Plugin.MediaManager.Abstractions/IMediaQueue.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/IMediaQueue.cs
@@ -38,7 +38,7 @@ namespace Plugin.MediaManager.Abstractions
         /// <summary>
         /// Activates or deactivates the Shuffle option
         /// </summary>
-        bool Shuffle { get; }
+        bool IsShuffled { get; }
 
         /// <summary>
         /// If the Queue has a next track

--- a/MediaManager/Plugin.MediaManager.Abstractions/Implementations/MediaQueue.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/Implementations/MediaQueue.cs
@@ -76,7 +76,7 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             }
         }
 
-        public bool Shuffle
+        public bool IsShuffled
         {
             get
             {
@@ -120,7 +120,7 @@ namespace Plugin.MediaManager.Abstractions.Implementations
                     throw new ArgumentNullException();
                 }
 
-                if (Shuffle)
+                if (IsShuffled)
                 {
                     var unshuffledIndex = _unshuffledQueue.IndexOf(_queue[index]);
                     _unshuffledQueue[unshuffledIndex] = value;
@@ -155,7 +155,7 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             _queue.Add(item);
 
             // If shuffle is enabled, we need to add the item to the backup queue too
-            if (Shuffle)
+            if (IsShuffled)
             {
                 _unshuffledQueue.Add(item);
             }
@@ -171,7 +171,7 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             _queue.AddRange(items);
 
             // If shuffle is enabled, we need to add the items to the backup queue too
-            if (Shuffle)
+            if (IsShuffled)
             {
                 _unshuffledQueue.AddRange(items);
             }
@@ -190,7 +190,7 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             if (_unshuffledQueue != null)
             {
                 _unshuffledQueue = null;
-                OnPropertyChanged(nameof(Shuffle));
+                OnPropertyChanged(nameof(IsShuffled));
             }
         }
 
@@ -291,7 +291,7 @@ namespace Plugin.MediaManager.Abstractions.Implementations
 
         public void ToggleShuffle()
         {
-            if (!Shuffle)
+            if (!IsShuffled)
             {
                 // Cancel any running tasks
                 shuffleCancellation.Cancel();
@@ -349,7 +349,7 @@ namespace Plugin.MediaManager.Abstractions.Implementations
                 Index = newIndex;
                 _unshuffledQueue = null;
             }
-            OnPropertyChanged(nameof(Shuffle));
+            OnPropertyChanged(nameof(IsShuffled));
         }
 
         protected void ReplaceQueueWith(IEnumerable<IMediaFile> files)
@@ -430,7 +430,7 @@ namespace Plugin.MediaManager.Abstractions.Implementations
 
         public void Insert(int index, IMediaFile item)
         {
-            if (Shuffle)
+            if (IsShuffled)
             {
                 _unshuffledQueue.Add(item);
             }
@@ -470,7 +470,7 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             }
 
             // If shuffle is enabled, we need to remove the item from the backup queue too
-            if (Shuffle)
+            if (IsShuffled)
             {
                 _unshuffledQueue.Remove(_queue[index]);
             }

--- a/MediaManager/Plugin.MediaManager.Tests/Tests/MediaQueueTests.cs
+++ b/MediaManager/Plugin.MediaManager.Tests/Tests/MediaQueueTests.cs
@@ -25,7 +25,7 @@ namespace Plugin.MediaManager.Tests.Tests
             Assert.AreEqual(null, queue.Current);
             Assert.AreEqual(-1, queue.Index);
             Assert.AreEqual(RepeatType.None, queue.Repeat);
-            Assert.AreEqual(false, queue.Shuffle);
+            Assert.AreEqual(false, queue.IsShuffled);
         }
 
         [TestFixture]
@@ -57,7 +57,7 @@ namespace Plugin.MediaManager.Tests.Tests
                 Assert.AreEqual(tracks[0], queue.Current);
                 Assert.AreEqual(0, queue.Index);
                 Assert.AreEqual(RepeatType.None, queue.Repeat);
-                Assert.AreEqual(false, queue.Shuffle);
+                Assert.AreEqual(false, queue.IsShuffled);
 
                 Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
                 Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -72,7 +72,7 @@ namespace Plugin.MediaManager.Tests.Tests
                 Assert.AreEqual(tracks[0], queue.Current);
                 Assert.AreEqual(0, queue.Index);
                 Assert.AreEqual(RepeatType.None, queue.Repeat);
-                Assert.AreEqual(false, queue.Shuffle);
+                Assert.AreEqual(false, queue.IsShuffled);
 
                 Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
                 Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -114,7 +114,7 @@ namespace Plugin.MediaManager.Tests.Tests
                 Assert.AreEqual(null, queue.Current);
                 Assert.AreEqual(-1, queue.Index);
                 Assert.AreEqual(RepeatType.None, queue.Repeat);
-                Assert.AreEqual(false, queue.Shuffle);
+                Assert.AreEqual(false, queue.IsShuffled);
 
                 Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
                 Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -154,7 +154,7 @@ namespace Plugin.MediaManager.Tests.Tests
                 Assert.AreEqual(null, queue.Current);
                 Assert.AreEqual(-1, queue.Index);
                 Assert.AreEqual(RepeatType.RepeatOne, queue.Repeat);
-                Assert.AreEqual(false, queue.Shuffle);
+                Assert.AreEqual(false, queue.IsShuffled);
 
                 Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
                 Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -196,7 +196,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(tracks[1], queue.Current);
 				Assert.AreEqual(1, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(0, propertyChangedEvents.Count);
 				Assert.AreEqual(1, collectionChangedEvents.Where(e => e.NewItems?.Count == 1 && e.OldItems?.Count == 1).Count());
@@ -231,7 +231,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(newMediaFile, queue.Current);
 				Assert.AreEqual(1, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
 				Assert.AreEqual(0, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -271,7 +271,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(tracks[1], queue.Current);
 				Assert.AreEqual(1, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(0, propertyChangedEvents.Count);
 				Assert.AreEqual(0, collectionChangedEvents.Count);
@@ -307,7 +307,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(tracks[1], queue.Current);
 				Assert.AreEqual(1, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(0, propertyChangedEvents.Count);
 				Assert.AreEqual(0, collectionChangedEvents.Count);
@@ -344,7 +344,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(tracks[1], queue.Current);
 				Assert.AreEqual(1, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(0, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
 				Assert.AreEqual(0, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -381,7 +381,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(tracks[1], queue.Current);
 				Assert.AreEqual(0, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(0, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
 				Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -418,7 +418,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(tracks[2], queue.Current);
 				Assert.AreEqual(1, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
 				Assert.AreEqual(0, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -455,7 +455,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(tracks[1], queue.Current);
 				Assert.AreEqual(1, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
 				Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -490,7 +490,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(null, queue.Current);
 				Assert.AreEqual(-1, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
 				Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -530,7 +530,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(tracks[1], queue.Current);
 				Assert.AreEqual(1, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(0, propertyChangedEvents.Count);
 				Assert.AreEqual(0, collectionChangedEvents.Count);
@@ -556,7 +556,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(null, queue.Current);
 				Assert.AreEqual(-1, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(0, propertyChangedEvents.Count);
 				Assert.AreEqual(0, collectionChangedEvents.Count);
@@ -591,7 +591,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(tracks[0], queue.Current);
 				Assert.AreEqual(0, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(0, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
 				Assert.AreEqual(0, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -626,7 +626,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(tracks[0], queue.Current);
 				Assert.AreEqual(1, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(0, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
 				Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -654,7 +654,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(newMediaFile, queue.Current);
 				Assert.AreEqual(0, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Current").Count());
 				Assert.AreEqual(1, propertyChangedEvents.Where(e => e.PropertyName == "Index").Count());
@@ -686,7 +686,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(null, queue.Current);
 				Assert.AreEqual(-1, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(0, propertyChangedEvents.Count);
 				Assert.AreEqual(0, collectionChangedEvents.Count);
@@ -720,7 +720,7 @@ namespace Plugin.MediaManager.Tests.Tests
 				Assert.AreEqual(tracks[0], queue.Current);
 				Assert.AreEqual(0, queue.Index);
 				Assert.AreEqual(RepeatType.None, queue.Repeat);
-				Assert.AreEqual(false, queue.Shuffle);
+				Assert.AreEqual(false, queue.IsShuffled);
 
 				Assert.AreEqual(0, propertyChangedEvents.Count);
 				Assert.AreEqual(0, collectionChangedEvents.Count);


### PR DESCRIPTION
This is a breaking change, if this is taken in it will require people to fix all references from Shuffle to IsShuffled.