### PR TITLE
Ignore XML comments missing warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,9 @@ bld/
 # Visual Studo 2015 cache/options directory
 .vs/
 
+# dotnet generated file
+project.lock.json
+
 # MSTest test Results
 [Tt]est[Rr]esult*/
 [Bb]uild[Ll]og.*

--- a/MediaManager/Plugin.MediaManager.Abstractions/Plugin.MediaManager.Abstractions.csproj
+++ b/MediaManager/Plugin.MediaManager.Abstractions/Plugin.MediaManager.Abstractions.csproj
@@ -34,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Plugin.MediaManager.Abstractions.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="IMediaFileMetadata.cs" />

--- a/MediaManager/Plugin.MediaManager.Android/Plugin.MediaManager.Android.csproj
+++ b/MediaManager/Plugin.MediaManager.Android/Plugin.MediaManager.Android.csproj
@@ -37,6 +37,7 @@
     <DocumentationFile>bin\Release\Plugin.MediaManager.XML</DocumentationFile>
     <AndroidSigningKeyAlias>
     </AndroidSigningKeyAlias>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Mono.Android" />

--- a/MediaManager/Plugin.MediaManager.ExoPlayer/Plugin.MediaManager.ExoPlayer.csproj
+++ b/MediaManager/Plugin.MediaManager.ExoPlayer/Plugin.MediaManager.ExoPlayer.csproj
@@ -37,6 +37,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidManagedSymbols>true</AndroidManagedSymbols>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/MediaManager/Plugin.MediaManager.MacOS/Plugin.MediaManager.MacOS.csproj
+++ b/MediaManager/Plugin.MediaManager.MacOS/Plugin.MediaManager.MacOS.csproj
@@ -55,6 +55,7 @@
     </LinkMode>
     <XamMacArch>
     </XamMacArch>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/MediaManager/Plugin.MediaManager.Reactive/Plugin.MediaManager.Reactive.csproj
+++ b/MediaManager/Plugin.MediaManager.Reactive/Plugin.MediaManager.Reactive.csproj
@@ -26,6 +26,7 @@
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/MediaManager/Plugin.MediaManager.iOS/Plugin.MediaManager.iOS.csproj
+++ b/MediaManager/Plugin.MediaManager.iOS/Plugin.MediaManager.iOS.csproj
@@ -34,6 +34,7 @@
     <ConsolePause>false</ConsolePause>
     <CodesignKey>iPhone Developer</CodesignKey>
     <DocumentationFile>bin\iPhone\Release\Plugin.MediaManager.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Plugin.MediaManager\CrossMediaManager.cs">

--- a/MediaManager/Plugin.MediaManager.tvOS/Plugin.MediaManager.tvOS.csproj
+++ b/MediaManager/Plugin.MediaManager.tvOS/Plugin.MediaManager.tvOS.csproj
@@ -43,6 +43,7 @@
     </MtouchHttpClientHandler>
     <MtouchTlsProvider>
     </MtouchTlsProvider>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/MediaManager/Plugin.MediaManager/Plugin.MediaManager.csproj
+++ b/MediaManager/Plugin.MediaManager/Plugin.MediaManager.csproj
@@ -34,6 +34,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>bin\Release\Plugin.MediaManager.XML</DocumentationFile>
+    <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->


### PR DESCRIPTION
This pull requests makes it so all warnings about missing comments on publicly accessible variables no longer generate warnings.

I also added project.lock.json to gitignore because the it crashed SourceTree all the time and it is generally recommended to not include it in source control