### PR TITLE
Moved CollectionChanged raising to end of IsShuffling setter.

### DIFF
--- a/MediaManager/Plugin.MediaManager.Abstractions/Implementations/MediaQueue.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/Implementations/MediaQueue.cs
@@ -96,6 +96,9 @@ namespace Plugin.MediaManager.Abstractions.Implementations
                         Unshuffle();
                     }
 
+                    if (CollectionChanged != null)
+                        CollectionChanged(_queue, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+
                     OnPropertyChanged(nameof(IsShuffled));
                 }
             }
@@ -298,8 +301,6 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             _queue.Clear();
             _queue.AddRange(files);
             CollectionChangedEventDisabled = false;
-            if (CollectionChanged != null)
-                CollectionChanged(_queue, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
         }
 
         private void Shuffle()


### PR DESCRIPTION
I moved the raising of this event handler so when the listener gets the event, the Current property has it's right value, which wasn't the case before when you did an unshuffle because the Index was set after the queue was replaced (And the CollectionChanged event raised).