### PR TITLE
Change order of Repeat toggle to be more intuitive

### DIFF
--- a/MediaManager/Plugin.MediaManager.Abstractions/Implementations/PlaybackController.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/Implementations/PlaybackController.cs
@@ -121,12 +121,12 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             switch (Queue.Repeat)
             {
                 case RepeatType.None:
-                    Queue.Repeat = RepeatType.RepeatOne;
-                    break;
-                case RepeatType.RepeatOne:
                     Queue.Repeat = RepeatType.RepeatAll;
                     break;
                 case RepeatType.RepeatAll:
+                    Queue.Repeat = RepeatType.RepeatOne;
+                    break;
+                case RepeatType.RepeatOne:
                     Queue.Repeat = RepeatType.None;
                     break;
             }


### PR DESCRIPTION
Changed the order to go from RepeatNone --> RepeatAll --> RepeatOne. Which is more intuitive IMO since you're going from least repeating to most. This is also the way Spotify and most other players have it.