### PR TITLE
Fixed issue with buffering on iOS 10 and greater.

### DIFF
--- a/MediaManager/Plugin.MediaManager.iOS/AudioPlayerImplementation.cs
+++ b/MediaManager/Plugin.MediaManager.iOS/AudioPlayerImplementation.cs
@@ -10,6 +10,7 @@ using Foundation;
 using Plugin.MediaManager.Abstractions;
 using Plugin.MediaManager.Abstractions.Enums;
 using Plugin.MediaManager.Abstractions.EventArguments;
+using UIKit;
 
 namespace Plugin.MediaManager
 {

--- a/MediaManager/Plugin.MediaManager.iOS/AudioPlayerImplementation.cs
+++ b/MediaManager/Plugin.MediaManager.iOS/AudioPlayerImplementation.cs
@@ -193,6 +193,11 @@ namespace Plugin.MediaManager
         {
             _player = new AVPlayer();
 
+            if (UIDevice.CurrentDevice.CheckSystemVersion(10, 0))
+            {
+                _player.AutomaticallyWaitsToMinimizeStalling = false;
+            }
+
 #if __IOS__ || __TVOS__
             var avSession = AVAudioSession.SharedInstance();
 


### PR DESCRIPTION
The behaviour for buffering changed in iOS 10. See the following property that was introduced:
https://developer.apple.com/reference/avfoundation/avplayer/1643482-automaticallywaitstominimizestal