### PR TITLE
Fixed issue that causes a crash when a media file fails.

### DIFF
--- a/MediaManager/Plugin.MediaManager.Abstractions/Implementations/MediaManagerBase.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/Implementations/MediaManagerBase.cs
@@ -208,7 +208,6 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             catch (Exception ex)
             {
                 OnMediaFileFailed(CurrentPlaybackManager, new MediaFileFailedEventArgs(ex, CurrentMediaFile));
-                throw;
             }
         }
 


### PR DESCRIPTION
Since the exceptions are already reported using the MediaFileFailed event, it is unnecessary to rethrow the exception. If this is not explicitly catched by the invoking method, the app will crash. I therefore remove the throw expression to avoid crashes that occurred.