### PR TITLE
Fixed an argument exception (TimeSpan.FromSeconds was called with NaN)

### DIFF
--- a/MediaManager/Plugin.MediaManager.iOS/AudioPlayerImplementation.cs
+++ b/MediaManager/Plugin.MediaManager.iOS/AudioPlayerImplementation.cs
@@ -389,7 +389,7 @@ namespace Plugin.MediaManager
             if (hasLoadedAnyTimeRanges)
             {
                 var range = loadedTimeRanges[0].CMTimeRangeValue;
-                var duration = TimeSpan.FromSeconds(range.Duration.Seconds);
+                var duration = double.IsNaN(range.Duration.Seconds) ? TimeSpan.Zero : TimeSpan.FromSeconds(range.Duration.Seconds);
                 var totalDuration = CurrentItem.Duration;
                 var bufferProgress = duration.TotalSeconds / totalDuration.Seconds;
                 BufferingChanged?.Invoke(this, new BufferingChangedEventArgs(bufferProgress, duration));


### PR DESCRIPTION
This should fix the following stack-trace I got reported at Insights on an iOS device:

> System.ArgumentExceptionTimeSpan does not accept floating point Not-a-Number values.
>
> System.TimeSpan.Interval(double value, int scale)
> System.TimeSpan.FromSeconds(double value)
> Plugin.MediaManager.AudioPlayerImplementation.ObserveLoadedTimeRanges()
> Plugin.MediaManager.AudioPlayerImplementation.ObserveValue(NSString keyPath, NSObject ofObject, NSDictionary change, IntPtr context)
> UIKit.UIApplication.UIApplicationMain(int, string[], intptr, intptr)(wrapper managed-to-native)
> UIKit.UIApplication.Main(string[] args, string principalClassName, string delegateClassName)

Since this error was thrown in production, I have no line-numbers attached to it.