### PR TITLE
Updated division-by-zero handling

### DIFF
--- a/MediaManager/Plugin.MediaManager.Android/Audio/AudioPlayerBase.cs
+++ b/MediaManager/Plugin.MediaManager.Android/Audio/AudioPlayerBase.cs
@@ -206,7 +206,7 @@ namespace Plugin.MediaManager
             var duration = Duration;
 
             PlayingChanged?.Invoke(this, new PlayingChangedEventArgs(
-                progress >= 0 ? progress : 0,
+                !double.IsInfinity(progress) ? progress : 0,
                 position.TotalSeconds >= 0 ? position : TimeSpan.Zero,
                 duration.TotalSeconds >= 0 ? duration : TimeSpan.Zero));
         }

--- a/MediaManager/Plugin.MediaManager.Android/Video/VideoPlayerImplementation.cs
+++ b/MediaManager/Plugin.MediaManager.Android/Video/VideoPlayerImplementation.cs
@@ -68,7 +68,7 @@ namespace Plugin.MediaManager
 			var duration = Duration;
 
 			PlayingChanged?.Invoke(this, new PlayingChangedEventArgs(
-				progress >= 0 ? progress : 0,
+			    !double.IsInfinity(progress) ? progress : 0,
 				position.TotalSeconds >= 0 ? position : TimeSpan.Zero,
 				duration.TotalSeconds >= 0 ? duration : TimeSpan.Zero));
 		}

--- a/MediaManager/Plugin.MediaManager.UWP/AudioPlayerImplementation.cs
+++ b/MediaManager/Plugin.MediaManager.UWP/AudioPlayerImplementation.cs
@@ -30,7 +30,7 @@ namespace Plugin.MediaManager
                 {
                     var progress = _player.PlaybackSession.Position.TotalSeconds/
                                    _player.PlaybackSession.NaturalDuration.TotalSeconds;
-                    if (double.IsNaN(progress))
+                    if (double.IsInfinity(progress))
                         progress = 0;
                     PlayingChanged?.Invoke(this, new PlayingChangedEventArgs(progress, _player.PlaybackSession.Position, _player.PlaybackSession.NaturalDuration));
                 }

--- a/MediaManager/Plugin.MediaManager.UWP/VideoPlayerImplementation.cs
+++ b/MediaManager/Plugin.MediaManager.UWP/VideoPlayerImplementation.cs
@@ -43,7 +43,7 @@ namespace Plugin.MediaManager
                 {
                     var progress = _player.PlaybackSession.Position.TotalSeconds/
                                    _player.PlaybackSession.NaturalDuration.TotalSeconds;
-                    if (double.IsNaN(progress))
+                    if (double.IsInfinity(progress))
                         progress = 0;
                     PlayingChanged?.Invoke(this, new PlayingChangedEventArgs(progress, _player.PlaybackSession.Position, _player.PlaybackSession.NaturalDuration));
                 }

--- a/MediaManager/Plugin.MediaManager.iOS/AudioPlayerImplementation.cs
+++ b/MediaManager/Plugin.MediaManager.iOS/AudioPlayerImplementation.cs
@@ -236,7 +236,11 @@ namespace Plugin.MediaManager
                     var totalDuration = TimeSpan.FromSeconds(CurrentItem.Duration.Seconds);
                     var totalProgress = Position.TotalMilliseconds /
                                         totalDuration.TotalMilliseconds;
-                    PlayingChanged?.Invoke(this, new PlayingChangedEventArgs(totalProgress, Position, Duration));
+                    PlayingChanged?.Invoke(this, new PlayingChangedEventArgs(
+                        !double.IsInfinity(totalProgress) ? totalProgress : 0,
+                        Position,
+                        Duration
+                    ));
                 }
             });
         }
@@ -392,7 +396,10 @@ namespace Plugin.MediaManager
                 var duration = double.IsNaN(range.Duration.Seconds) ? TimeSpan.Zero : TimeSpan.FromSeconds(range.Duration.Seconds);
                 var totalDuration = CurrentItem.Duration;
                 var bufferProgress = duration.TotalSeconds / totalDuration.Seconds;
-                BufferingChanged?.Invoke(this, new BufferingChangedEventArgs(bufferProgress, duration));
+                BufferingChanged?.Invoke(this, new BufferingChangedEventArgs(
+                    !double.IsInfinity(bufferProgress) ? bufferProgress : 0,
+                    duration
+                ));
             }
             else
             {

--- a/MediaManager/Plugin.MediaManager.iOS/VideoPlayerImplementation.cs
+++ b/MediaManager/Plugin.MediaManager.iOS/VideoPlayerImplementation.cs
@@ -197,7 +197,10 @@ namespace Plugin.MediaManager
 					totalProgress = Position.TotalMilliseconds /
 										totalDuration.TotalMilliseconds;
 				}
-                PlayingChanged?.Invoke(this, new PlayingChangedEventArgs(totalProgress, Position, Duration));
+                PlayingChanged?.Invoke(this, new PlayingChangedEventArgs(
+                    !double.IsInfinity(totalProgress) ? totalProgress : 0,
+                    Position,
+                    Duration));
             });
         }
 
@@ -302,10 +305,13 @@ namespace Plugin.MediaManager
             if (loadedTimeRanges.Length > 0)
             {
                 var range = loadedTimeRanges[0].CMTimeRangeValue;
-                var duration = TimeSpan.FromSeconds(range.Duration.Seconds);
+                var duration = double.IsNaN(range.Duration.Seconds) ? TimeSpan.Zero : TimeSpan.FromSeconds(range.Duration.Seconds);
                 var totalDuration = _player.CurrentItem.Duration;
                 var bufferProgress = duration.TotalSeconds / totalDuration.Seconds;
-                BufferingChanged?.Invoke(this, new BufferingChangedEventArgs(bufferProgress, duration));
+                BufferingChanged?.Invoke(this, new BufferingChangedEventArgs(
+                    !double.IsInfinity(bufferProgress) ? bufferProgress : 0,
+                    duration
+                ));
             }
             else
             {


### PR DESCRIPTION
This should catch up with devision-by-zero handling, when the duration is 0, the position gets `Infinite` or `-Infinite` (and not `NaN` as claimed in the UWP version - see the example here: https://msdn.microsoft.com/en-us/library/system.double.isinfinity(v=vs.110).aspx).

I've also fixed #147 for videos 😉 