### PR TITLE
Fixed calling `Position`, `Duration` or `Buffered` when `CurrentPlaybackManager` isn’t defined

### DIFF
--- a/MediaManager/Plugin.MediaManager.Abstractions/Implementations/MediaManagerBase.cs
+++ b/MediaManager/Plugin.MediaManager.Abstractions/Implementations/MediaManagerBase.cs
@@ -46,11 +46,11 @@ namespace Plugin.MediaManager.Abstractions.Implementations
 
         public MediaPlayerStatus Status => CurrentPlaybackManager?.Status ?? MediaPlayerStatus.Stopped;
 
-        public TimeSpan Position => CurrentPlaybackManager.Position;
+        public TimeSpan Position => CurrentPlaybackManager?.Position ?? TimeSpan.Zero;
 
-        public TimeSpan Duration => CurrentPlaybackManager.Duration;
+        public TimeSpan Duration => CurrentPlaybackManager?.Duration ?? TimeSpan.Zero;
 
-        public TimeSpan Buffered => CurrentPlaybackManager.Buffered;
+        public TimeSpan Buffered => CurrentPlaybackManager?.Buffered ?? TimeSpan.Zero;
 
         public event StatusChangedEventHandler StatusChanged;
 


### PR DESCRIPTION
Should fix this stacktrace:

> System.NullReferenceExceptionObject reference not set to an instance of an object
> 
> Plugin.MediaManager.Abstractions.Implementations.MediaManagerBase.get_Duration()<37290f3ebc7342948d1e410443a3c068>:0
> Plugin.MediaManager.Abstractions.Implementations.PlaybackController.<SeekTo>d__20.MoveNext()<37290f3ebc7342948d1e410443a3c068>:0
> Plugin.MediaManager.Abstractions.Implementations.PlaybackController.<SeekToStart>d__17.MoveNext()<37290f3ebc7342948d1e410443a3c068>:0
> Plugin.MediaManager.Abstractions.Implementations.PlaybackController.<PlayPrevious>d__16.MoveNext()<37290f3ebc7342948d1e410443a3c068>:0