### PR TITLE
Updated call for MPMediaItemArtwork to confirm cover isn’t nil

### DIFF
--- a/MediaManager.iOS/MediaNotificationManagerImplementation.cs
+++ b/MediaManager.iOS/MediaNotificationManagerImplementation.cs
@@ -85,9 +85,9 @@ namespace Plugin.MediaManager
                 nowPlayingInfo.PlaybackRate = 0f;
             }
 
-            if (metadata.AlbumArt != null)
+            var cover = metadata.AlbumArt as UIImage;
+            if (cover != null)
             {
-                var cover = (UIImage) metadata.AlbumArt;
                 nowPlayingInfo.Artwork = new MPMediaItemArtwork(cover);
             }
 


### PR DESCRIPTION
Should fix the following crash I found in Insights:

```
0 libsystem_kernel.dylib __pthread_kill (in libsystem_kernel.dylib) + 8
1 libsystem_c.dylib abort (in libsystem_c.dylib) + 140
2 MyMediaPlayerApp -[PLCrashReporter generateLiveReportWithThread:] (in 3ec122779f9f33fb9cd4636415e6dba8) + 0
3 CoreFoundation __handleUncaughtException (in CoreFoundation) + 644
4 libobjc.A.dylib objc_terminate() (in libobjc.dylib) + 112
5 libc++abi.dylib std::__terminate() (in libc++abi.dylib) + 16
6 libc++abi.dylib _cxxabiv1::exception_cleanup_func() (in libc++abi.dylib) + 0
7 libobjc.A.dylib objc_exception_destructor() (in libobjc.dylib) + 0
8 CoreFoundation -[NSException initWithCoder:] (in CoreFoundation) + 0
9 MediaPlayer -[MPMediaItemArtwork initWithImage:] (in MediaPlayer) + 216
10 MyMediaPlayerApp wrapper_managed_to_native_ObjCRuntime_Messaging_objc_msgSend_intptr_intptr_intptr (in 3ec122779f9f33fb9cd4636415e6dba8) + 112
11 MyMediaPlayerApp Xamarin_iOS_MediaPlayer_MPMediaItemArtwork__ctor_UIKit_UIImage (in 3ec122779f9f33fb9cd4636415e6dba8) + 64
12 MyMediaPlayerApp Plugin_MediaManager_Plugin_MediaManager_MediaNotificationManagerImplementation_CreateNowPlayingInfo_Plugin_MediaManager_Abstractions_IMediaFile (in 3ec122779f9f33fb9cd4636415e6dba8) + 968
13 MyMediaPlayerApp Plugin_MediaManager_Plugin_MediaManager_MediaNotificationManagerImplementation_UpdateNotifications_Plugin_MediaManager_Abstractions_IMediaFile_Plugin_MediaManager_Abstractions_Enums_MediaPlayerStatus (in 3ec122779f9f33fb9cd4636415e6dba8) + 20
14 MyMediaPlayerApp Plugin_MediaManager_Abstractions_Plugin_MediaManager_Abstractions_Implementations_MediaManagerBase_OnMediaFileChanged_object_Plugin_MediaManager_Abstractions_EventArguments_MediaFileChangedEventArgs (in 3ec122779f9f33fb9cd4636415e6dba8) + 244
15 MyMediaPlayerApp Plugin_MediaManager_Abstractions_Plugin_MediaManager_Abstractions_Implementations_MediaManagerBase__ExtractMediaInformationd__82_MoveNext (in 3ec122779f9f33fb9cd4636415e6dba8) + 408
16 MyMediaPlayerApp InvokeMoveNext (in 3ec122779f9f33fb9cd4636415e6dba8) (AsyncMethodBuilder.cs:1089)
17 MyMediaPlayerApp RunInternal (in 3ec122779f9f33fb9cd4636415e6dba8) (executioncontext.cs:957)
18 MyMediaPlayerApp Run (in 3ec122779f9f33fb9cd4636415e6dba8) (AsyncMethodBuilder.cs:1070)
19 MyMediaPlayerApp InvokeAction (in 3ec122779f9f33fb9cd4636415e6dba8) (TaskContinuation.cs:741)
```