### PR TITLE
Normalize progress on Android and iOS

### DIFF
--- a/MediaManager.Android/Video/VideoPlayerImplementation.cs
+++ b/MediaManager.Android/Video/VideoPlayerImplementation.cs
@@ -63,7 +63,7 @@ namespace Plugin.MediaManager
 
 		private void OnPlaying()
 		{
-			var progress = (Position.TotalSeconds / Duration.TotalSeconds) * 100;
+			var progress = (Position.TotalSeconds / Duration.TotalSeconds);
 			var position = Position;
 			var duration = Duration;
 


### PR DESCRIPTION
on iOs platform there's no multiplication by 100 as removed from android, what force users to use workaround to treat this.