### PR TITLE
Updated .gitignore to include *.nuget.targets" files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -139,6 +139,7 @@ publish/
 
 # NuGet Packages
 *.nupkg
+*.nuget.targets
 # The packages folder can be ignored because of Package Restore
 **/packages/*
 # except build/, which is used as an MSBuild target.


### PR DESCRIPTION
I found that Git is recently finding the following changes when building the solution:

> modified:   ../MediaManager.Forms/MediaManager.Forms.UWP/Plugin.MediaManager.Forms.UWP.nuget.targets
> modified:   ../Samples/Forms/MediaForms.UWP/MediaForms.UWP.nuget.targets

I'm not sure if it's because I upgraded to VS 2017, or some other reason. These appear to be user-specific files, so I added these types of files to .gitignore.