### PR TITLE
Fixed Issue #71

### DIFF
--- a/MediaManager.Android/MediaPlayerService/MediaServiceBase.cs
+++ b/MediaManager.Android/MediaPlayerService/MediaServiceBase.cs
@@ -347,13 +347,6 @@ namespace Plugin.MediaManager
             if (isNewFile)
                 return await Task.FromResult(false);
 
-            //Same file selected => seek to start
-            if (MediaPlayerState != PlaybackStateCompat.StatePaused && !ManuallyPaused)
-            {
-                await Seek(TimeSpan.Zero);
-                return await Task.FromResult(true);
-            }
-            
             //just paused.. restart playback!
             if (MediaPlayerState == PlaybackStateCompat.StatePaused && ManuallyPaused)
             {


### PR DESCRIPTION
Removed logic from MediaServiceBase.CheckIfFileAlreadyIsPlaying() that prevented playing the same media file twice in a row. This fixes Issue #71 

I'm not sure of the original purpose for that piece of logic. I have been testing it and have found no ill effects of removing it.  If you know any needed purpose for it, let me know and maybe we can figure out a solution that works all around.