### PR TITLE
PlaybackController instance is no longer lost

### DIFF
--- a/MediaManager.UWP.Tests/Plugin.MediaManager.UWP.Tests.csproj
+++ b/MediaManager.UWP.Tests/Plugin.MediaManager.UWP.Tests.csproj
@@ -100,6 +100,7 @@
       <DependentUpon>UnitTestApp.xaml</DependentUpon>
     </Compile>
     <Compile Include="Unit\MediaButtonPlaybackControllerTest.cs" />
+    <Compile Include="Unit\PlaybackControllerProviderMock.cs" />
   </ItemGroup>
   <ItemGroup>
     <ApplicationDefinition Include="UnitTestApp.xaml">

--- a/MediaManager.UWP.Tests/Unit/MediaButtonPlaybackControllerTest.cs
+++ b/MediaManager.UWP.Tests/Unit/MediaButtonPlaybackControllerTest.cs
@@ -14,7 +14,7 @@ namespace Plugin.MediaManager.UWP.Tests.Unit
         {
             var controlsMock = new Mock<ISystemMediaTransportControlsWrapper>();
 
-            new MediaButtonPlaybackController(controlsMock.Object, new Mock<IPlaybackController>().Object);
+            new MediaButtonPlaybackController(controlsMock.Object, new PlaybackControllerProviderMock().Object);
 
             controlsMock.VerifySet(m => m.IsNextEnabled = true);
             controlsMock.VerifySet(m => m.IsPreviousEnabled = true);
@@ -28,7 +28,7 @@ namespace Plugin.MediaManager.UWP.Tests.Unit
         {
             var controlsMock = new Mock<ISystemMediaTransportControlsWrapper>();
 
-            var controller = new MediaButtonPlaybackController(controlsMock.Object, new Mock<IPlaybackController>().Object);
+            var controller = new MediaButtonPlaybackController(controlsMock.Object, new PlaybackControllerProviderMock().Object);
             controller.SubscribeToNotifications();
 
             controlsMock.Verify(m => m.SubscribeToMediaButtonEvents());
@@ -39,7 +39,7 @@ namespace Plugin.MediaManager.UWP.Tests.Unit
         {
             var controlsMock = new Mock<ISystemMediaTransportControlsWrapper>();
 
-            var controller = new MediaButtonPlaybackController(controlsMock.Object, new Mock<IPlaybackController>().Object);
+            var controller = new MediaButtonPlaybackController(controlsMock.Object, new PlaybackControllerProviderMock().Object);
             controller.UnsubscribeFromNotifications();
 
             controlsMock.Verify(m => m.UnsubscribeFromMediaButtonEvents());
@@ -50,8 +50,9 @@ namespace Plugin.MediaManager.UWP.Tests.Unit
         {
             var controlsMock = new Mock<ISystemMediaTransportControlsWrapper>();
             var playbackControllerMock = new Mock<IPlaybackController>();
+            var playbackControllerProviderMock = new PlaybackControllerProviderMock().SetupGetPlayBackController(playbackControllerMock.Object);
 
-            var controller = new MediaButtonPlaybackController(controlsMock.Object, playbackControllerMock.Object);
+            var controller = new MediaButtonPlaybackController(controlsMock.Object, playbackControllerProviderMock.Object);
             controller.SubscribeToNotifications();
 
             var args = new Mock<ISystemMediaTransportControlsButtonPressedEventArgsWrapper>();
@@ -66,8 +67,9 @@ namespace Plugin.MediaManager.UWP.Tests.Unit
         {
             var controlsMock = new Mock<ISystemMediaTransportControlsWrapper>();
             var playbackControllerMock = new Mock<IPlaybackController>();
+            var playbackControllerProviderMock = new PlaybackControllerProviderMock().SetupGetPlayBackController(playbackControllerMock.Object);
 
-            var controller = new MediaButtonPlaybackController(controlsMock.Object, playbackControllerMock.Object);
+            var controller = new MediaButtonPlaybackController(controlsMock.Object, playbackControllerProviderMock.Object);
             controller.SubscribeToNotifications();
 
             var args = new Mock<ISystemMediaTransportControlsButtonPressedEventArgsWrapper>();
@@ -82,8 +84,9 @@ namespace Plugin.MediaManager.UWP.Tests.Unit
         {
             var controlsMock = new Mock<ISystemMediaTransportControlsWrapper>();
             var playbackControllerMock = new Mock<IPlaybackController>();
+            var playbackControllerProviderMock = new PlaybackControllerProviderMock().SetupGetPlayBackController(playbackControllerMock.Object);
 
-            var controller = new MediaButtonPlaybackController(controlsMock.Object, playbackControllerMock.Object);
+            var controller = new MediaButtonPlaybackController(controlsMock.Object, playbackControllerProviderMock.Object);
             controller.SubscribeToNotifications();
 
             var args = new Mock<ISystemMediaTransportControlsButtonPressedEventArgsWrapper>();
@@ -98,8 +101,9 @@ namespace Plugin.MediaManager.UWP.Tests.Unit
         {
             var controlsMock = new Mock<ISystemMediaTransportControlsWrapper>();
             var playbackControllerMock = new Mock<IPlaybackController>();
+            var playbackControllerProviderMock = new PlaybackControllerProviderMock().SetupGetPlayBackController(playbackControllerMock.Object);
 
-            var controller = new MediaButtonPlaybackController(controlsMock.Object, playbackControllerMock.Object);
+            var controller = new MediaButtonPlaybackController(controlsMock.Object, playbackControllerProviderMock.Object);
             controller.SubscribeToNotifications();
 
             var args = new Mock<ISystemMediaTransportControlsButtonPressedEventArgsWrapper>();
@@ -114,8 +118,9 @@ namespace Plugin.MediaManager.UWP.Tests.Unit
         {
             var controlsMock = new Mock<ISystemMediaTransportControlsWrapper>();
             var playbackControllerMock = new Mock<IPlaybackController>();
+            var playbackControllerProviderMock = new PlaybackControllerProviderMock().SetupGetPlayBackController(playbackControllerMock.Object);
 
-            var controller = new MediaButtonPlaybackController(controlsMock.Object, playbackControllerMock.Object);
+            var controller = new MediaButtonPlaybackController(controlsMock.Object, playbackControllerProviderMock.Object);
             controller.SubscribeToNotifications();
 
             var args = new Mock<ISystemMediaTransportControlsButtonPressedEventArgsWrapper>();

--- a/MediaManager.UWP.Tests/Unit/PlaybackControllerProviderMock.cs
+++ b/MediaManager.UWP.Tests/Unit/PlaybackControllerProviderMock.cs
@@ -1,0 +1,14 @@
+using Moq;
+using Plugin.MediaManager.Abstractions;
+
+namespace Plugin.MediaManager.UWP.Tests.Unit
+{
+    internal class PlaybackControllerProviderMock : Mock<IPlaybackControllerProvider>
+    {
+        public PlaybackControllerProviderMock SetupGetPlayBackController(IPlaybackController playbackController)
+        {
+            Setup(mock => mock.PlaybackController).Returns(playbackController);
+            return this;
+        }
+    }
+}

--- a/MediaManager.UWP/IPlaybackControllerProvider.cs
+++ b/MediaManager.UWP/IPlaybackControllerProvider.cs
@@ -1,0 +1,9 @@
+﻿using Plugin.MediaManager.Abstractions;
+
+namespace Plugin.MediaManager
+{
+    internal interface IPlaybackControllerProvider
+    {
+        IPlaybackController PlaybackController { get; }
+    }
+}

--- a/MediaManager.UWP/MediaButtonPlaybackController.cs
+++ b/MediaManager.UWP/MediaButtonPlaybackController.cs
@@ -7,12 +7,12 @@ namespace Plugin.MediaManager
     internal class MediaButtonPlaybackController
     {
         private readonly ISystemMediaTransportControlsWrapper _systemMediaTransportControlsWrapper;
-        private readonly IPlaybackController _playbackController;
+        private readonly IPlaybackControllerProvider _playbackControllerProvider;
 
-        public MediaButtonPlaybackController(ISystemMediaTransportControlsWrapper systemMediaTransportControlsWrapper, IPlaybackController playbackController)
+        public MediaButtonPlaybackController(ISystemMediaTransportControlsWrapper systemMediaTransportControlsWrapper, IPlaybackControllerProvider playbackControllerProvider)
         {
             _systemMediaTransportControlsWrapper = systemMediaTransportControlsWrapper;
-            _playbackController = playbackController;
+            _playbackControllerProvider = playbackControllerProvider;
 
             _systemMediaTransportControlsWrapper.IsNextEnabled = true;
             _systemMediaTransportControlsWrapper.IsPreviousEnabled = true;
@@ -38,19 +38,19 @@ namespace Plugin.MediaManager
             switch (args.Button)
             {
                 case SystemMediaTransportControlsButton.Next:
-                    await _playbackController.PlayNext();
+                    await _playbackControllerProvider.PlaybackController.PlayNext();
                     break;
                 case SystemMediaTransportControlsButton.Previous:
-                    await _playbackController.PlayPreviousOrSeekToStart();
+                    await _playbackControllerProvider.PlaybackController.PlayPreviousOrSeekToStart();
                     break;
                 case SystemMediaTransportControlsButton.Play:
-                    await _playbackController.Play();
+                    await _playbackControllerProvider.PlaybackController.Play();
                     break;
                 case SystemMediaTransportControlsButton.Pause:
-                    await _playbackController.Pause();
+                    await _playbackControllerProvider.PlaybackController.Pause();
                     break;
                 case SystemMediaTransportControlsButton.Stop:
-                    await _playbackController.Stop();
+                    await _playbackControllerProvider.PlaybackController.Stop();
                     break;
             }
         }

--- a/MediaManager.UWP/MediaButtonPlaybackController.cs
+++ b/MediaManager.UWP/MediaButtonPlaybackController.cs
@@ -4,7 +4,7 @@ using Plugin.MediaManager.SystemWrappers;
 
 namespace Plugin.MediaManager
 {
-    public class MediaButtonPlaybackController
+    internal class MediaButtonPlaybackController
     {
         private readonly ISystemMediaTransportControlsWrapper _systemMediaTransportControlsWrapper;
         private readonly IPlaybackController _playbackController;

--- a/MediaManager.UWP/MediaManagerImplementation.cs
+++ b/MediaManager.UWP/MediaManagerImplementation.cs
@@ -8,7 +8,7 @@ namespace Plugin.MediaManager
     /// <summary>
     ///     Implementation for Feature
     /// </summary>
-    public class MediaManagerImplementation : MediaManagerBase
+    public class MediaManagerImplementation : MediaManagerBase, IPlaybackControllerProvider
     {
         private IAudioPlayer _audioPlayer;
         private IVideoPlayer _videoPlayer;
@@ -17,7 +17,7 @@ namespace Plugin.MediaManager
         public MediaManagerImplementation()
         {
             var systemMediaTransportControlsWrapper = new SystemMediaTransportControlsWrapper(SystemMediaTransportControls.GetForCurrentView());
-            _mediaButtonPlaybackController = new MediaButtonPlaybackController(systemMediaTransportControlsWrapper, PlaybackController);
+            _mediaButtonPlaybackController = new MediaButtonPlaybackController(systemMediaTransportControlsWrapper, this);
             _mediaButtonPlaybackController.SubscribeToNotifications();
         }
 

--- a/MediaManager.UWP/Plugin.MediaManager.UWP.csproj
+++ b/MediaManager.UWP/Plugin.MediaManager.UWP.csproj
@@ -138,6 +138,9 @@
       <Name>Plugin.MediaManager.Abstractions</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="project.json" />
+  </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>

--- a/MediaManager.UWP/Plugin.MediaManager.UWP.csproj
+++ b/MediaManager.UWP/Plugin.MediaManager.UWP.csproj
@@ -113,6 +113,7 @@
       <Link>CrossMediaManager.cs</Link>
     </Compile>
     <Compile Include="AudioPlayerImplementation.cs" />
+    <Compile Include="IPlaybackControllerProvider.cs" />
     <Compile Include="SystemWrappers\ISystemMediaTransportControlsWrapper.cs" />
     <Compile Include="SystemWrappers\ISystemMediaTransportControlsButtonPressedEventArgsWrapper.cs" />
     <Compile Include="MediaExtractorImplementation.cs" />

--- a/MediaManager.UWP/Properties/AssemblyInfo.cs
+++ b/MediaManager.UWP/Properties/AssemblyInfo.cs
@@ -27,3 +27,5 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
 [assembly: ComVisible(false)]
+[assembly: InternalsVisibleTo("Plugin.MediaManager.UWP.Tests")]
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2")]

--- a/MediaManager.UWP/SystemWrappers/ISystemMediaTransportControlsButtonPressedEventArgsWrapper.cs
+++ b/MediaManager.UWP/SystemWrappers/ISystemMediaTransportControlsButtonPressedEventArgsWrapper.cs
@@ -2,7 +2,7 @@
 
 namespace Plugin.MediaManager.SystemWrappers
 {
-    public interface ISystemMediaTransportControlsButtonPressedEventArgsWrapper
+    internal interface ISystemMediaTransportControlsButtonPressedEventArgsWrapper
     {
         SystemMediaTransportControlsButton Button { get; }
     }

--- a/MediaManager.UWP/SystemWrappers/ISystemMediaTransportControlsWrapper.cs
+++ b/MediaManager.UWP/SystemWrappers/ISystemMediaTransportControlsWrapper.cs
@@ -1,10 +1,9 @@
-﻿using System;
-using Windows.Foundation;
+﻿using Windows.Foundation;
 using Windows.Media;
 
 namespace Plugin.MediaManager.SystemWrappers
 {
-    public interface ISystemMediaTransportControlsWrapper
+    internal interface ISystemMediaTransportControlsWrapper
     {
         void SubscribeToMediaButtonEvents();
 

--- a/MediaManager.UWP/SystemWrappers/SystemMediaTransportControlsButtonPressedEventArgsWrapper.cs
+++ b/MediaManager.UWP/SystemWrappers/SystemMediaTransportControlsButtonPressedEventArgsWrapper.cs
@@ -1,8 +1,8 @@
-using Windows.Media;
+﻿using Windows.Media;
 
 namespace Plugin.MediaManager.SystemWrappers
 {
-    class SystemMediaTransportControlsButtonPressedEventArgsWrapper : ISystemMediaTransportControlsButtonPressedEventArgsWrapper
+    internal class SystemMediaTransportControlsButtonPressedEventArgsWrapper : ISystemMediaTransportControlsButtonPressedEventArgsWrapper
     {
         public SystemMediaTransportControlsButton Button { get; }
 

--- a/MediaManager.UWP/SystemWrappers/SystemMediaTransportControlsWrapper.cs
+++ b/MediaManager.UWP/SystemWrappers/SystemMediaTransportControlsWrapper.cs
@@ -3,7 +3,7 @@ using Windows.Media;
 
 namespace Plugin.MediaManager.SystemWrappers
 {
-    class SystemMediaTransportControlsWrapper : ISystemMediaTransportControlsWrapper
+    internal class SystemMediaTransportControlsWrapper : ISystemMediaTransportControlsWrapper
     {
         private readonly SystemMediaTransportControls _controls;
 


### PR DESCRIPTION
This is a step towards solving issue #229. The PlaybackController instance now reflects the setting of the PlaybackController property on MediaManagerInstance for UWP. This would also need to be done for Android (and I guess IOS)