### PR TITLE
Fix for droid service remaining after app kill

### DIFF
--- a/MediaManager.Android/MediaPlayerService/MediaPlayerService.cs
+++ b/MediaManager.Android/MediaPlayerService/MediaPlayerService.cs
@@ -93,7 +93,7 @@ namespace Plugin.MediaManager
         public override StartCommandResult OnStartCommand(Intent intent, StartCommandFlags flags, int startId)
         {
             HandleIntent(intent);
-            return base.OnStartCommand(intent, flags, startId);
+            return StartCommandResult.NotSticky;// base.OnStartCommand(intent, flags, startId);
         }
 
         public override async Task Play(IMediaFile mediaFile = null)


### PR DESCRIPTION
I ran into an issue where the media player service is left active in the notification area if the app is killed while playing.

This code change resolves that issue.