### PR TITLE
Changes to resolve metadata issues on IOS

### DIFF
--- a/MediaManager.Abstractions/Implementations/MediaFile.cs
+++ b/MediaManager.Abstractions/Implementations/MediaFile.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Plugin.MediaManager.Abstractions.Enums;
 using Plugin.MediaManager.Abstractions.EventArguments;
 
@@ -15,7 +15,7 @@ namespace Plugin.MediaManager.Abstractions.Implementations
         }
 
         public MediaFile(string url, MediaFileType type) : this(url, type, default(ResourceAvailability))
-        { 
+        {
         }
 
         public MediaFile(string url, MediaFileType type, ResourceAvailability availability)
@@ -36,12 +36,20 @@ namespace Plugin.MediaManager.Abstractions.Implementations
         public string Url { get; set; }
 
         private bool _metadataExtracted;
-        public bool MetadataExtracted { get {
+        public bool MetadataExtracted
+        {
+            get
+            {
                 return _metadataExtracted;
-            } set {
+            }
+            set
+            {
                 _metadataExtracted = value;
                 MetadataUpdated?.Invoke(this, new MetadataChangedEventArgs(Metadata));
-            } }
+            }
+        }
+
+        public bool ExtractMetadata { get; set; } = true;
 
         public event MetadataUpdatedEventHandler MetadataUpdated;
     }

--- a/Samples/Forms/MediaForms/HomePage.xaml
+++ b/Samples/Forms/MediaForms/HomePage.xaml
@@ -8,10 +8,14 @@
                 <Button x:Name="mainBtn"
                     Text="Click here to view a video"
                     Clicked="MainBtn_OnClicked" />
-                <Button Text="Play A Audio"
-                    Clicked="PlayAudio_OnClicked" />
+                <Button Text="Play Audio (Show ID3 Metadata)"
+                        Clicked="PlayAudio_OnClicked" />
+                <Button Text="Play Audio (Show User Metadata)"
+                        Clicked="PlayAudioMyTrack_OnClicked" />
                 <Button Text="Play Audio List"
                     Clicked="PlaylistButton_OnClicked" />
+                <Button Text="Stop Audio"
+                    Clicked="StopButton_OnClicked" />
             </StackLayout>
 	        <StackLayout Orientation="Horizontal" VerticalOptions="End" Grid.Row="2">
 		        <Label x:Name="volumeLabel" Text="Volume (0-100):" HorizontalOptions="Start"></Label>

--- a/Samples/Forms/MediaForms/HomePage.xaml.cs
+++ b/Samples/Forms/MediaForms/HomePage.xaml.cs
@@ -26,6 +26,11 @@ namespace MediaForms
             Navigation.PushAsync(new MediaFormsPage());
         }
 
+        private async void StopButton_OnClicked(object sender, EventArgs e)
+        {
+            await CrossMediaManager.Current.Stop();
+        }
+        
         private async void PlayAudio_OnClicked(object sender, EventArgs e)
         {
             var mediaFile = new MediaFile
@@ -33,12 +38,23 @@ namespace MediaForms
                 Type = MediaFileType.Audio,
                 Availability = ResourceAvailability.Remote,
                 Url = "https://audioboom.com/posts/5766044-follow-up-305.mp3",
-                Metadata = new MediaFileMetadata() {Title = "My Title", Artist = "My Artist", Album = "My Album"},
-                ExtractMetadata = false
+                ExtractMetadata = true
             };
             await CrossMediaManager.Current.Play(mediaFile);
         }
 
+        private async void PlayAudioMyTrack_OnClicked(object sender, EventArgs e)
+        {
+            var mediaFile = new MediaFile
+            {
+                Type = MediaFileType.Audio,
+                Availability = ResourceAvailability.Remote,
+                Url = "https://audioboom.com/posts/5766044-follow-up-305.mp3",
+                Metadata = new MediaFileMetadata() { Title = "My Title", Artist = "My Artist", Album = "My Album" },
+                ExtractMetadata = false
+            };
+            await CrossMediaManager.Current.Play(mediaFile);
+        }
         private async void PlaylistButton_OnClicked(object sender, EventArgs e)
         {
             var list = new List<MediaFile>


### PR DESCRIPTION
Changes to support user entered metadata for IOS Remote Control.

Plus additions to the MediaForms Sample project to show how these changes work, plus a stop button.

And the Implementations MediaFile update to include ExtractMetadata.  I forgot this one in the android PR.