### PR TITLE
NETSTANDARD: Found SIGSEVG Crash

### DIFF
--- a/MediaManager.Abstractions/IMediaManager.cs
+++ b/MediaManager.Abstractions/IMediaManager.cs
@@ -51,7 +51,6 @@ namespace Plugin.MediaManager.Abstractions
 
         Task Play();
         Task Play(string url, MediaItemType type);
-        Task Play(IMediaItem item);
 
         Task Play(IEnumerable<IMediaItem> items);
 

--- a/MediaManager.Abstractions/Implementations/MediaManagerBase.cs
+++ b/MediaManager.Abstractions/Implementations/MediaManagerBase.cs
@@ -206,10 +206,11 @@ namespace Plugin.MediaManager.Abstractions.Implementations
 
             MediaQueue.SetTrackAsCurrent(MediaItem);
 
-            await RaiseMediaItemFailedEventOnException(async () =>
-            {
-                await PlayCurrent();
-            });
+            //await RaiseMediaItemFailedEventOnException(async () =>
+            //{
+            //    await PlayCurrent();
+            //});
+            await AudioPlayer.Play(MediaItem);
 
             NotificationManager?.StartNotification(MediaItem);
         }
@@ -264,7 +265,6 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             await CurrentPlaybackManager.Play(CurrentMediaItem);
         }
 
-        [DebuggerStepThrough]
         private async Task RaiseMediaItemFailedEventOnException(Func<Task> action)
         {
             try
@@ -282,7 +282,6 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             return PrepareCurrentAndThen(() => CurrentPlaybackManager.Play(CurrentMediaItem));
         }
 
-        [DebuggerStepThrough]
         private async Task PrepareCurrentAndThen(Func<Task> action = null)
         {
             await ExecuteOnBeforePlay();
@@ -293,14 +292,12 @@ namespace Plugin.MediaManager.Abstractions.Implementations
                     ExtractMediaInformation(CurrentMediaItem));
         }
 
-        [DebuggerStepThrough]
         private async Task ExecuteOnBeforePlay()
         {
             var beforePlayTask = _onBeforePlay?.Invoke(CurrentMediaItem);
             if (beforePlayTask != null) await beforePlayTask;
         }
 
-        [DebuggerStepThrough]
         private void SetCurrentPlayer(MediaItemType fileType)
         {
             if (_currentPlaybackManager != null)
@@ -321,7 +318,6 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             AddEventHandlers();
         }
 
-        [DebuggerStepThrough]
         private async Task ExtractMediaInformation(IMediaItem MediaItem)
         {
             var index = MediaQueue.IndexOf(MediaItem);

--- a/MediaManager.Abstractions/Implementations/MediaQueue.cs
+++ b/MediaManager.Abstractions/Implementations/MediaQueue.cs
@@ -12,7 +12,6 @@ using Plugin.MediaManager.Abstractions.EventArguments;
 
 namespace Plugin.MediaManager.Abstractions.Implementations
 {
-    [DebuggerStepThrough]
     public class MediaQueue : IMediaQueue
     {
         public MediaQueue()
@@ -405,7 +404,6 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             _count = _queue.Count;
         }
 
-        [DebuggerStepThrough]
         private void RegisterCurrentTriggers()
         {
             var updateProperty = new Action(() =>

--- a/MediaManager.Abstractions/Implementations/PlaybackController.cs
+++ b/MediaManager.Abstractions/Implementations/PlaybackController.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using Plugin.MediaManager.Abstractions.Enums;
 
@@ -6,94 +7,7 @@ namespace Plugin.MediaManager.Abstractions.Implementations
 {
     public class PlaybackController : IPlaybackController
     {
-        private MediaManagerBase mediaManagerBase;
-
-        public PlaybackController(MediaManagerBase mediaManagerBase)
-        {
-            this.mediaManagerBase = mediaManagerBase;
-        }
-
-        public Task Pause()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task Play()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task PlayFromQueueByIndex(int index)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task PlayFromQueueByMediaItem(IMediaItem file)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task PlayNext()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task PlayPause()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task PlayPrevious()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task PlayPreviousOrSeekToStart()
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task SeekBackward(TimeSpan? time = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task SeekForward(TimeSpan? time = null)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task SeekTo(TimeSpan position)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task SeekToStart()
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetRating()
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetRepeatMode(RepeatMode type)
-        {
-            throw new NotImplementedException();
-        }
-
-        public void SetShuffleMode(ShuffleMode type)
-        {
-            throw new NotImplementedException();
-        }
-
-        public Task Stop()
-        {
-            throw new NotImplementedException();
-        }
-
-        /*private readonly IMediaManager _mediaManager;
+        private readonly IMediaManager _mediaManager;
 
         public virtual double StepSeconds => 10;
 
@@ -110,10 +24,10 @@ namespace Plugin.MediaManager.Abstractions.Implementations
 
         public virtual async Task PlayPause()
         {
-            var status = _mediaManager.Status;
+            var state = _mediaManager.State;
 
-            var isPaused = status == PlaybackState.Paused;
-            var isStopped = status == PlaybackState.Stopped;
+            var isPaused = state == PlaybackState.Paused;
+            var isStopped = state == PlaybackState.Stopped;
 
             if (isPaused || isStopped)
             {
@@ -157,6 +71,16 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             await _mediaManager.PlayNext();
         }
 
+        public async Task PlayFromQueueByIndex(int index)
+        {
+            //TODO: PlayFromQueueByIndex
+        }
+
+        public async Task PlayFromQueueByMediaItem(IMediaItem file)
+        {
+            //TODO: PlayFromQueueByMediaItem
+        }
+
         public virtual async Task PlayPrevious()
         {
             if (Queue.HasPrevious())
@@ -174,16 +98,46 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             await SeekTo(0);
         }
 
-        public virtual async Task StepForward()
+        public async Task SeekForward(TimeSpan? time = null)
         {
-            var destination = PositionSeconds + StepSeconds;
+            if (time != null) await StepForward(time.Value.TotalSeconds);
+        }
+
+        public async Task SeekBackward(TimeSpan? time = null)
+        {
+            if (time != null) await StepBackward(time.Value.TotalSeconds);
+        }
+
+        public async Task SeekTo(TimeSpan position)
+        {
+            await SeekTo(position.TotalSeconds);
+        }
+
+        public void SetRepeatMode(RepeatMode type)
+        {
+            ToggleRepeat();
+        }
+
+        public void SetShuffleMode(ShuffleMode type)
+        {
+            ToggleShuffle();
+        }
+
+        public void SetRating()
+        {
+            //TODO: SetRating
+        }
+
+        public virtual async Task StepForward(double stepSeconds)
+        {
+            var destination = PositionSeconds + stepSeconds;
 
             await SeekTo(destination);
         }
 
-        public virtual async Task StepBackward()
+        public virtual async Task StepBackward(double stepSeconds)
         {
-            var destination = PositionSeconds - StepSeconds;
+            var destination = PositionSeconds - stepSeconds;
 
             await SeekTo(destination);
         }
@@ -193,7 +147,8 @@ namespace Plugin.MediaManager.Abstractions.Implementations
             if (_mediaManager.Duration.TotalSeconds < seconds)
             {
                 seconds = _mediaManager.Duration.TotalSeconds;
-            } else if (seconds < 0)
+            }
+            else if (seconds < 0)
             {
                 seconds = 0;
             }
@@ -222,6 +177,6 @@ namespace Plugin.MediaManager.Abstractions.Implementations
         public virtual void ToggleShuffle()
         {
             Queue.IsShuffled = !Queue.IsShuffled;
-        }*/
+        }
     }
 }

--- a/MediaManager.Android/Audio/AudioPlayerImplementation.cs
+++ b/MediaManager.Android/Audio/AudioPlayerImplementation.cs
@@ -44,23 +44,14 @@ namespace Plugin.MediaManager.Audio
             mediaBrowser = new MediaBrowserCompat(_mediaManagerImplementation.Context, new ComponentName(_mediaManagerImplementation.Context, Java.Lang.Class.FromType(typeof(AudioPlayerService))), mediaBrowserConnectionCallback, null);
             mediaBrowser.Connect();
 
-            //return true;
             return await tcs.Task;
         }
 
         public PlaybackState State => _mediaManagerImplementation.State;
-
         public TimeSpan Position => _mediaManagerImplementation.Position;
-
         public TimeSpan Duration => _mediaManagerImplementation.Duration;
-
         public TimeSpan Buffered => _mediaManagerImplementation.Buffered;
-
-        public Dictionary<string, string> RequestHeaders
-        {
-            get => _mediaManagerImplementation.RequestHeaders;
-            set => _mediaManagerImplementation.RequestHeaders = value;
-        }
+        public Dictionary<string, string> RequestHeaders { get; set; } = new Dictionary<string, string>();
 
         public event StatusChangedEventHandler Status;
         public event PlayingChangedEventHandler Playing;
@@ -93,7 +84,8 @@ namespace Plugin.MediaManager.Audio
                     .SetDescription(item.Metadata.DisplayDescription)
                     .SetSubtitle(item.Metadata.DisplaySubtitle)
                     .SetIconBitmap(item.Metadata.DisplayIcon as Bitmap);
-                if (item.Metadata.DisplayIconUri != string.Empty) _builder.SetIconUri(Android.Net.Uri.Parse(item.Metadata.DisplayIconUri));
+                if (!string.IsNullOrEmpty(item.Metadata.DisplayIconUri))
+                    _builder.SetIconUri(Android.Net.Uri.Parse(item.Metadata.DisplayIconUri));
 
                 //var test = new Android.OS.Bundle();
                 mediaController.GetTransportControls().PlayFromMediaId(_builder.Build().MediaId, Bundle.Empty);

--- a/MediaManager.Android/Audio/AudioPlayerImplementation.cs
+++ b/MediaManager.Android/Audio/AudioPlayerImplementation.cs
@@ -47,10 +47,10 @@ namespace Plugin.MediaManager.Audio
             return await tcs.Task;
         }
 
-        public PlaybackState State => _mediaManagerImplementation.State;
-        public TimeSpan Position => _mediaManagerImplementation.Position;
-        public TimeSpan Duration => _mediaManagerImplementation.Duration;
-        public TimeSpan Buffered => _mediaManagerImplementation.Buffered;
+        public PlaybackState State => PlaybackState.Loading;
+        public TimeSpan Position => new TimeSpan();
+        public TimeSpan Duration => new TimeSpan();
+        public TimeSpan Buffered => new TimeSpan();
         public Dictionary<string, string> RequestHeaders { get; set; } = new Dictionary<string, string>();
 
         public event StatusChangedEventHandler Status;
@@ -61,13 +61,14 @@ namespace Plugin.MediaManager.Audio
 
         public Task Pause()
         {
-            mediaController.GetTransportControls().Pause();
+            mediaController?.GetTransportControls().Pause();
             return Task.CompletedTask;
         }
 
         public async Task Play(string url)
         {
-            if (await ConnectService()) mediaController.GetTransportControls().PlayFromUri(Android.Net.Uri.Parse(url), null);
+            if (await ConnectService())
+                mediaController?.GetTransportControls().PlayFromUri(Android.Net.Uri.Parse(url), null);
         }
 
         public async Task Play(IMediaItem item)
@@ -87,19 +88,21 @@ namespace Plugin.MediaManager.Audio
                 if (!string.IsNullOrEmpty(item.Metadata.DisplayIconUri))
                     _builder.SetIconUri(Android.Net.Uri.Parse(item.Metadata.DisplayIconUri));
 
-                //var test = new Android.OS.Bundle();
-                mediaController.GetTransportControls().PlayFromMediaId(_builder.Build().MediaId, Bundle.Empty);
+                mediaController?.GetTransportControls().PlayFromMediaId(_builder.Build().MediaId, Bundle.Empty);
             }
         }
 
         public async Task Seek(TimeSpan position)
         {
-            if (await ConnectService()) if (long.TryParse(position.TotalSeconds.ToString(), out var pos)) mediaController.GetTransportControls().SeekTo(pos);
+            if (await ConnectService())
+                if (long.TryParse(position.TotalSeconds.ToString(), out var pos))
+                    mediaController?.GetTransportControls().SeekTo(pos);
         }
 
         public async Task Stop()
         {
-            if (await ConnectService()) mediaController.GetTransportControls().Stop();
+            if (await ConnectService())
+                mediaController?.GetTransportControls().Stop();
         }
     }
 }

--- a/MediaManager.Android/Audio/AudioPlayerImplementation.cs
+++ b/MediaManager.Android/Audio/AudioPlayerImplementation.cs
@@ -88,23 +88,21 @@ namespace Plugin.MediaManager.Audio
             {
                 var _builder = new MediaDescriptionCompat.Builder();
 
-                var description = _builder.SetMediaId(new Guid().ToString())
+                _builder.SetMediaId(new Guid().ToString())
                     .SetTitle(item.Metadata.DisplayTitle)
                     .SetDescription(item.Metadata.DisplayDescription)
                     .SetSubtitle(item.Metadata.DisplaySubtitle)
-                    .SetIconUri(Android.Net.Uri.Parse(item.Metadata.DisplayIconUri))
-                    .SetIconBitmap(item.Metadata.DisplayIcon as Bitmap)
-                    .Build();
+                    .SetIconBitmap(item.Metadata.DisplayIcon as Bitmap);
+                if (item.Metadata.DisplayIconUri != string.Empty) _builder.SetIconUri(Android.Net.Uri.Parse(item.Metadata.DisplayIconUri));
 
                 //var test = new Android.OS.Bundle();
-                mediaController.GetTransportControls().PlayFromMediaId(description.MediaId, Bundle.Empty);
+                mediaController.GetTransportControls().PlayFromMediaId(_builder.Build().MediaId, Bundle.Empty);
             }
         }
 
         public async Task Seek(TimeSpan position)
         {
             if (await ConnectService()) if (long.TryParse(position.TotalSeconds.ToString(), out var pos)) mediaController.GetTransportControls().SeekTo(pos);
-
         }
 
         public async Task Stop()

--- a/MediaManager.Android/Audio/AudioPlayerImplementation.cs
+++ b/MediaManager.Android/Audio/AudioPlayerImplementation.cs
@@ -15,7 +15,6 @@ namespace Plugin.MediaManager.Audio
     public class AudioPlayerImplementation : Java.Lang.Object, IAudioPlayer
     {
         private MediaManagerImplementation _mediaManagerImplementation;
-
         public MediaBrowserCompat mediaBrowser { get; private set; }
         public MediaControllerCompat mediaController { get; private set; }
         public MediaBrowserConnectionCallback mediaBrowserConnectionCallback { get; private set; }
@@ -59,7 +58,8 @@ namespace Plugin.MediaManager.Audio
 
         public Dictionary<string, string> RequestHeaders
         {
-            get => _mediaManagerImplementation.RequestHeaders; set => _mediaManagerImplementation.RequestHeaders = value;
+            get => _mediaManagerImplementation.RequestHeaders;
+            set => _mediaManagerImplementation.RequestHeaders = value;
         }
 
         public event StatusChangedEventHandler Status;
@@ -70,13 +70,13 @@ namespace Plugin.MediaManager.Audio
 
         public Task Pause()
         {
+            mediaController.GetTransportControls().Pause();
             return Task.CompletedTask;
         }
 
         public async Task Play(string url)
         {
-            await ConnectService();
-            mediaController.GetTransportControls().PlayFromUri(Android.Net.Uri.Parse(url), null);
+            if (await ConnectService()) mediaController.GetTransportControls().PlayFromUri(Android.Net.Uri.Parse(url), null);
         }
 
         public async Task Play(IMediaItem item)
@@ -103,12 +103,13 @@ namespace Plugin.MediaManager.Audio
 
         public async Task Seek(TimeSpan position)
         {
-            await ConnectService();
+            if (await ConnectService()) if (long.TryParse(position.TotalSeconds.ToString(), out var pos)) mediaController.GetTransportControls().SeekTo(pos);
+
         }
 
         public async Task Stop()
         {
-            await ConnectService();
+            if (await ConnectService()) mediaController.GetTransportControls().Stop();
         }
     }
 }

--- a/MediaManager.Android/Audio/AudioPlayerService.cs
+++ b/MediaManager.Android/Audio/AudioPlayerService.cs
@@ -15,12 +15,10 @@ namespace Plugin.MediaManager.Audio
     {
         public AudioPlayerService()
         {
-            Debugger.Break();
         }
 
         protected AudioPlayerService(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
         {
-            Debugger.Break();
         }
 
         protected MediaSessionCompat _mediaSession;

--- a/MediaManager.Android/Audio/MediaSessionCallback.cs
+++ b/MediaManager.Android/Audio/MediaSessionCallback.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Android.OS;
 using Android.Support.V4.Media.Session;
 
@@ -6,11 +6,11 @@ namespace Plugin.MediaManager.Audio
 {
     public class MediaSessionCallback : MediaSessionCompat.Callback
     {
-        private AudioPlayerService audioPlayerService;
+        private AudioPlayerService _audioPlayerService;
 
         public MediaSessionCallback(AudioPlayerService audioPlayerService)
         {
-            this.audioPlayerService = audioPlayerService;
+            _audioPlayerService = audioPlayerService;
         }
 
         public Action OnPlayImpl { get; set; }
@@ -40,7 +40,7 @@ namespace Plugin.MediaManager.Audio
 
         public override void OnSkipToQueueItem(long id)
         {
-            OnSkipToQueueItemImpl?.Invoke(id);
+            OnSkipToQueueItemImpl(id);
         }
 
         public override void OnSeekTo(long pos)

--- a/MediaManager.Android/MediaItemExtensions.cs
+++ b/MediaManager.Android/MediaItemExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System;
+using System;
+using Android.Graphics;
 using Android.Support.V4.Media;
 using Plugin.MediaManager.Abstractions;
 using static Android.Support.V4.Media.MediaBrowserCompat;
@@ -10,12 +11,18 @@ namespace Plugin.MediaManager
     {
         public static MediaItem ToMediaItem(this IMediaItem item)
         {
-            
+            var _builder = new MediaDescriptionCompat.Builder();
 
-            MediaDescriptionCompat description = new MediaDescriptionCompat.Builder().SetTitle("test").Build();
-            var test = new MediaItem(description, MediaItem.FlagPlayable);
-            //var test2 = new QueueItem(description);
-            return test;
+            _builder.SetMediaId(new Guid().ToString())
+                .SetTitle(item.Metadata.DisplayTitle)
+                .SetDescription(item.Metadata.DisplayDescription)
+                .SetSubtitle(item.Metadata.DisplaySubtitle)
+                .SetIconBitmap(item.Metadata.DisplayIcon as Bitmap)
+                .SetMediaUri(Android.Net.Uri.Parse(item.Url));
+
+            if (!string.IsNullOrEmpty(item.Metadata.DisplayIconUri))
+                _builder.SetIconUri(Android.Net.Uri.Parse(item.Metadata.DisplayIconUri));
+            return new MediaItem(_builder.Build(), MediaItem.FlagPlayable);
         }
     }
 }

--- a/MediaManager.Android/MediaItemExtensions.cs
+++ b/MediaManager.Android/MediaItemExtensions.cs
@@ -11,6 +11,11 @@ namespace Plugin.MediaManager
     {
         public static MediaItem ToMediaItem(this IMediaItem item)
         {
+            //MediaDescriptionCompat description = new MediaDescriptionCompat.Builder().SetTitle("test").Build();
+            //var test = new MediaItem(description, MediaItem.FlagPlayable);
+            ////var test2 = new QueueItem(description);
+            //return test;
+
             var _builder = new MediaDescriptionCompat.Builder();
 
             _builder.SetMediaId(new Guid().ToString())
@@ -20,8 +25,7 @@ namespace Plugin.MediaManager
                 .SetIconBitmap(item.Metadata.DisplayIcon as Bitmap)
                 .SetMediaUri(Android.Net.Uri.Parse(item.Url));
 
-            if (!string.IsNullOrEmpty(item.Metadata.DisplayIconUri))
-                _builder.SetIconUri(Android.Net.Uri.Parse(item.Metadata.DisplayIconUri));
+            if (!string.IsNullOrEmpty(item.Metadata.DisplayIconUri)) _builder.SetIconUri(Android.Net.Uri.Parse(item.Metadata.DisplayIconUri));
             return new MediaItem(_builder.Build(), MediaItem.FlagPlayable);
         }
     }

--- a/MediaManager.Android/NotificationManagerImplementation.cs
+++ b/MediaManager.Android/NotificationManagerImplementation.cs
@@ -6,11 +6,11 @@ namespace Plugin.MediaManager
 {
     public class NotificationManagerImplementation : INotificationManager
     {
-        private MediaManagerImplementation mediaManagerImplementation;
+        private MediaManagerImplementation _mediaManagerImplementation;
 
         public NotificationManagerImplementation(MediaManagerImplementation mediaManagerImplementation)
         {
-            this.mediaManagerImplementation = mediaManagerImplementation;
+            _mediaManagerImplementation = mediaManagerImplementation;
         }
 
         public void StartNotification(IMediaItem item)

--- a/MediaManager.Android/NotificationManagerImplementation.cs
+++ b/MediaManager.Android/NotificationManagerImplementation.cs
@@ -15,17 +15,17 @@ namespace Plugin.MediaManager
 
         public void StartNotification(IMediaItem item)
         {
-            ////throw new NotImplementedException();
+            //TODO: StartNotification
         }
 
         public void StopNotifications()
         {
-            ////throw new NotImplementedException();
+            //TODO: StopNotification
         }
 
         public void UpdateNotifications(IMediaItem item, PlaybackState state)
         {
-            ////throw new NotImplementedException();
+            //TODO: UpdateNotification
         }
     }
 }

--- a/MediaManager.Android/Video/VideoPlayerImplementation.cs
+++ b/MediaManager.Android/Video/VideoPlayerImplementation.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Android.App;
 using Android.Media;
 using Android.OS;
 using Android.Runtime;
@@ -23,11 +24,11 @@ namespace Plugin.MediaManager
             this._mediaManagerImplementation = mediaManagerImplementation;
         }
 
-        public IVideoSurface RenderSurface { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public IVideoSurface RenderSurface { get; set; } 
 
-        public bool IsReadyRendering => throw new NotImplementedException();
+        public bool IsReadyRendering { get; private set; }
 
-        public VideoAspectMode AspectMode { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public VideoAspectMode AspectMode { get; set; } = VideoAspectMode.None;
         private bool _IsMuted = false;
         public bool IsMuted
         {

--- a/MediaManager.Android/VolumeManagerImplementation.cs
+++ b/MediaManager.Android/VolumeManagerImplementation.cs
@@ -7,14 +7,14 @@ namespace Plugin.MediaManager
 {
     public class VolumeManagerImplementation : VolumeProviderCompat.Callback, IVolumeManager
     {
-        private MediaManagerImplementation mediaManagerImplementation;
+        private MediaManagerImplementation _mediaManagerImplementation;
 
         public VolumeManagerImplementation(MediaManagerImplementation mediaManagerImplementation)
         {
-            this.mediaManagerImplementation = mediaManagerImplementation;
+            _mediaManagerImplementation = mediaManagerImplementation;
         }
 
-        public int  CurrentVolume { get; set; }
+        public int CurrentVolume { get; set; }
 
         public int MaxVolume { get; set; }
 

--- a/MediaManager/CrossMediaManager.cs
+++ b/MediaManager/CrossMediaManager.cs
@@ -28,11 +28,12 @@ namespace Plugin.MediaManager
             }
         }
 
+        [DebuggerStepThrough]
         static IMediaManager CreateMediaManager()
         {
 #if PORTABLE
-        Debug.WriteLine("PORTABLE Reached");
-        return null;
+            Debug.WriteLine("PORTABLE Reached");
+            return null;
 #else
             Debug.WriteLine("Other reached");
             return new MediaManagerImplementation();

--- a/Samples/Forms/Droid/Properties/AndroidManifest.xml
+++ b/Samples/Forms/Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,9 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.media.mediaforms">
-	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="24" />
+﻿<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.media.mediaforms" android:installLocation="auto">
+	<uses-sdk android:minSdkVersion="15" />
+	<uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+	<uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.MEDIA_CONTENT_CONTROL" />
+	<uses-permission android:name="android.permission.WAKE_LOCK" />
 	<application android:label="MediaForms"></application>
 </manifest>


### PR DESCRIPTION
Changed MediaManagerBase back to match initial "Play" call after NetStandard Branch and mediaBrowser.Connect() no longer crashes.  The problem is somewhere in the "PlayCurrent" functionality.
Here are the key lines of code in MediaManagerBase (209-213) that resolved the SIGSEVG:
            //await RaiseMediaItemFailedEventOnException(async () =>
            //{
            //    await PlayCurrent();
            //});
            await AudioPlayer.Play(MediaItem);