### PR TITLE
Duplicate StatusChanged event calls (Resolves Issue #303)

### DIFF
--- a/MediaManager.Android/MediaPlayerService/MediaServiceBase.cs
+++ b/MediaManager.Android/MediaPlayerService/MediaServiceBase.cs
@@ -145,7 +145,6 @@ namespace Plugin.MediaManager
 
         public virtual Task Pause()
         {
-            OnStatusChanged(new StatusChangedEventArgs(MediaPlayerStatus.Paused));
             SessionManager.UpdatePlaybackState(PlaybackStateCompat.StatePaused, Position.Seconds);
             return Task.CompletedTask;
         }

--- a/MediaManager.ExoPlayer/ExoPlayerAudioService.cs
+++ b/MediaManager.ExoPlayer/ExoPlayerAudioService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
@@ -171,7 +171,7 @@ namespace Plugin.MediaManager.ExoPlayer
             {
                 var status = GetStatusByIntValue(state);
                 var compatState = GetCompatValueByStatus(status);
-                OnStatusChanged(new StatusChangedEventArgs(status));
+                //OnStatusChanged(new StatusChangedEventArgs(status));
                 SessionManager.UpdatePlaybackState(compatState, Position.Seconds);
             }
         }

--- a/MediaManager.iOS/AudioPlayerImplementation.cs
+++ b/MediaManager.iOS/AudioPlayerImplementation.cs
@@ -40,6 +40,8 @@ namespace Plugin.MediaManager
 
             _status = MediaPlayerStatus.Stopped;
 
+            InitializePlayer();
+
             // Watch the buffering status. If it changes, we may have to resume because the playing stopped because of bad network-conditions.
             BufferingChanged += (sender, e) =>
             {

--- a/MediaManager.iOS/AudioPlayerImplementation.cs
+++ b/MediaManager.iOS/AudioPlayerImplementation.cs
@@ -40,8 +40,6 @@ namespace Plugin.MediaManager
 
             _status = MediaPlayerStatus.Stopped;
 
-            InitializePlayer();
-
             // Watch the buffering status. If it changes, we may have to resume because the playing stopped because of bad network-conditions.
             BufferingChanged += (sender, e) =>
             {


### PR DESCRIPTION
I removed the preceeding OnStatusChanged calls as OnStatusChanged is invoked within the UpdatePlaylistState function.