### PR TITLE
Fix UpdateAndroidNotificationManagerSettings call

### DIFF
--- a/MediaManager.Android/MediaSession/MediaSessionManager.cs
+++ b/MediaManager.Android/MediaSession/MediaSessionManager.cs
@@ -80,10 +80,10 @@ namespace Plugin.MediaManager.MediaSession
 
                     RemoteComponentName = new ComponentName(packageName, new RemoteControlBroadcastReceiver().ComponentName);
                     mediaSessionCompat = new MediaSessionCompat(applicationContext, "XamarinStreamingAudio", RemoteComponentName, pIntent);
-                    UpdateAndroidNotificationManagerSettings();
 
                     mediaControllerCompat = new MediaControllerCompat(applicationContext, mediaSessionCompat.SessionToken);
                     _notificationManager = _overrideNotificationManager ?? new MediaNotificationManagerImplementation(applicationContext, typeof(MediaPlayerService));
+                    UpdateAndroidNotificationManagerSettings();
                 }
                 mediaSessionCompat.Active = true;
                 MediaServiceBase mediaServiceBase = binder.GetMediaPlayerService<MediaServiceBase>();


### PR DESCRIPTION
Right now, `MediaNotificationManagerImplementation.AddActionButtons` is not working, since MediaQueue is always `null`. This is, because `UpdateAndroidNotificationManagerSettings` is called before _notificationManager is constructed in `InitMediaSession`. So buttons would otherwise only work, if the `NotificationManager` property was set.