### PR TITLE
Fix to allow loading IOS Artwork from URL via AlbumArtUri

### DIFF
--- a/MediaManager.iOS/MediaNotificationManagerImplementation.cs
+++ b/MediaManager.iOS/MediaNotificationManagerImplementation.cs
@@ -1,4 +1,5 @@
-﻿using MediaPlayer;
+using Foundation;
+using MediaPlayer;
 using Plugin.MediaManager.Abstractions;
 using Plugin.MediaManager.Abstractions.Enums;
 using UIKit;
@@ -85,10 +86,22 @@ namespace Plugin.MediaManager
                 nowPlayingInfo.PlaybackRate = 0f;
             }
 
-            var cover = metadata.AlbumArt as UIImage;
-            if (cover != null)
+            if (metadata.AlbumArt != null)
             {
-                nowPlayingInfo.Artwork = new MPMediaItemArtwork(cover);
+                var cover = metadata.AlbumArt as UIImage;
+                if (cover != null)
+                {
+                    nowPlayingInfo.Artwork = new MPMediaItemArtwork(cover);
+                }
+            }
+            if (!metadata.AlbumArtUri.Equals(string.Empty))
+            {
+
+                var cover = UIImage.LoadFromData(NSData.FromUrl(new NSUrl(metadata.AlbumArtUri)));
+                if (cover != null)
+                {
+                    nowPlayingInfo.Artwork = new MPMediaItemArtwork(cover);
+                }
             }
 
             return nowPlayingInfo;

--- a/MediaManager.iOS/MediaNotificationManagerImplementation.cs
+++ b/MediaManager.iOS/MediaNotificationManagerImplementation.cs
@@ -94,9 +94,8 @@ namespace Plugin.MediaManager
                     nowPlayingInfo.Artwork = new MPMediaItemArtwork(cover);
                 }
             }
-            if (!metadata.AlbumArtUri.Equals(string.Empty))
+            if (!string.IsNullOrEmpty(metadata.AlbumArtUri))
             {
-
                 var cover = UIImage.LoadFromData(NSData.FromUrl(new NSUrl(metadata.AlbumArtUri)));
                 if (cover != null)
                 {


### PR DESCRIPTION
Adding a URI to the MediaFile Metadata AlbumArtUri property will now display the artwork in the IOS lock screen