### PR TITLE
Fixed Position and Duration Problem for Android Devices

### DIFF
--- a/MediaManager.Android/Video/VideoPlayerImplementation.cs
+++ b/MediaManager.Android/Video/VideoPlayerImplementation.cs
@@ -218,9 +218,9 @@ namespace Plugin.MediaManager
 
         public TimeSpan Buffered => IsReadyRendering == false ? TimeSpan.Zero : TimeSpan.FromSeconds(VideoViewCanvas.BufferPercentage);
 
-        public TimeSpan Duration => IsReadyRendering == false ? TimeSpan.Zero : TimeSpan.FromSeconds(VideoViewCanvas.Duration);
+        public TimeSpan Duration => IsReadyRendering == false ? TimeSpan.Zero : TimeSpan.FromMilliseconds(VideoViewCanvas.Duration);
 
-        public TimeSpan Position => IsReadyRendering == false ? TimeSpan.Zero : TimeSpan.FromSeconds(VideoViewCanvas.CurrentPosition);
+        public TimeSpan Position => IsReadyRendering == false ? TimeSpan.Zero : TimeSpan.FromMilliseconds(VideoViewCanvas.CurrentPosition);
 
         private int lastPosition = 0;
 


### PR DESCRIPTION
Changes the VideoPlayerImplementation Duration and Position to TimeSpan.FromMilliseconds because the Android VideoViewCanvas.CurrentPosition provides milliseconds, not seconds.