### PR TITLE
Use MetaData.Album for Album, rather than MetaData.Artist

### DIFF
--- a/MediaManager.Android/MediaSession/MediaSessionManager.cs
+++ b/MediaManager.Android/MediaSession/MediaSessionManager.cs
@@ -186,7 +186,7 @@ namespace Plugin.MediaManager.MediaSession
             if (currentTrack != null)
             {
                 builder
-                    .PutString(MediaMetadata.MetadataKeyAlbum, currentTrack.Metadata.Artist)
+                    .PutString(MediaMetadata.MetadataKeyAlbum, currentTrack.Metadata.Album)
                     .PutString(MediaMetadata.MetadataKeyArtist, currentTrack.Metadata.Artist)
                     .PutString(MediaMetadata.MetadataKeyTitle, currentTrack.Metadata.Title);
             }


### PR DESCRIPTION
Minor bug fix while trying to figure out the class.
As title says, use the Metadata.Album for Album, instead of Artist.