### PR TITLE
Exoplayer needs to call Stop() twice before state is actually "Stopped".

### DIFF
--- a/MediaManager.ExoPlayer/ExoPlayerAudioService.cs
+++ b/MediaManager.ExoPlayer/ExoPlayerAudioService.cs
@@ -208,7 +208,7 @@ namespace Plugin.MediaManager.ExoPlayer
                 case Com.Google.Android.Exoplayer2.ExoPlayer.StateReady:
                     return !ManuallyPaused && !TransientPaused ? MediaPlayerStatus.Playing : MediaPlayerStatus.Paused;
                 case Com.Google.Android.Exoplayer2.ExoPlayer.StateIdle:
-                    return MediaPlayerStatus.Loading;
+                    return MediaPlayerStatus.Stopped;
                 default:
                     return MediaPlayerStatus.Failed;
             }


### PR DESCRIPTION
When calling Stop() it currently changes state to "Stopped", "Loading" then "Playing". This is not what you expect to happen. According to the [docs of the ExoPlayer](https://google.github.io/ExoPlayer/doc/reference/com/google/android/exoplayer2/Player.html#STATE_IDLE) the STATE_IDLE is when it has nothing to play, so converting it to the MediaPlayerStatus.Stopped seem most suitable.

Furthermore i noticed that the `GetCompatValueByStatus(MediaPlayerStatus state)` returns `PlaybackStateCompat.StateSkippingToQueueItem;` if `MediaPlayerStatus.Loading` I believe that is wrong? I haven't changed it as i thought it might have impact on queued items?

**Commits**:
StateIdle == Nothing to play according to exoplayer docs. Its also the default state, and Stopped is the default state of MediaPlayerStatus.