### PR TITLE
MediaFailed is never called, as it was set up wrong  on android.

### DIFF
--- a/MediaManager.Android/MediaPlayerService/MediaServiceBase.cs
+++ b/MediaManager.Android/MediaPlayerService/MediaServiceBase.cs
@@ -125,7 +125,7 @@ namespace Plugin.MediaManager
             catch (Exception ex)
             {
                 dataSourceSet = false;
-                OnMediaFileFailed(new MediaFileFailedEventArgs(ex, mediaFile));
+                OnMediaFailed(new MediaFailedEventArgs(ex.ToString(), ex));
             }
 
             if (dataSourceSet)
@@ -140,7 +140,7 @@ namespace Plugin.MediaManager
                 }
                 catch (Exception ex)
                 {
-                    OnMediaFileFailed(new MediaFileFailedEventArgs(ex, CurrentFile));
+                    OnMediaFailed(new MediaFailedEventArgs(ex.ToString(), ex));
                 }
             }
         }

--- a/MediaManager.ExoPlayer/ExoPlayerAudioService.cs
+++ b/MediaManager.ExoPlayer/ExoPlayerAudioService.cs
@@ -158,7 +158,7 @@ namespace Plugin.MediaManager.ExoPlayer
 
         public void OnPlayerError(ExoPlaybackException ex)
         {
-            OnMediaFileFailed(new MediaFileFailedEventArgs(ex, CurrentFile));
+            OnMediaFailed(new MediaFailedEventArgs(ex.ToString(), ex));
         }
 
         public void OnPlayerStateChanged(bool playWhenReady, int state)
@@ -301,7 +301,7 @@ namespace Plugin.MediaManager.ExoPlayer
         
         public void OnLoadError(IOException ex)
         {
-            OnMediaFileFailed(new MediaFileFailedEventArgs(ex, CurrentFile));
+            OnMediaFailed(new MediaFailedEventArgs(ex.ToString(), ex));
         }
     }
 


### PR DESCRIPTION
MediaFileFailed was wrongly used to tell if there was an error with the playback. The MediaFileFailed says its used for Media metadata fails, so i've changed it to use the MediaFailed event instead just as the other players on the other platforms.