### PR TITLE
Use AudioFocus.Gain

### DIFF
--- a/MediaManager.Android/MediaPlayerService/MediaServiceBase.cs
+++ b/MediaManager.Android/MediaPlayerService/MediaServiceBase.cs
@@ -132,7 +132,7 @@ namespace Plugin.MediaManager
             {
                 try
                 {
-                    var focusResult = AudioManager.RequestAudioFocus(this, Stream.Music, AudioFocus.LossTransientCanDuck);
+                    var focusResult = AudioManager.RequestAudioFocus(this, Stream.Music, AudioFocus.Gain);
                     if (focusResult != AudioFocusRequest.Granted)
                         Console.WriteLine("Could not get audio focus");
 


### PR DESCRIPTION
Request AudioFocus.Gain instead of LossTransientCanDuck.

If its really needed for anyone to play with LossTransientCanDuck we should make it possible to change this during playback start.