### PR TITLE
Fix to use DisplayTitle when specified.

### DIFF
--- a/MediaManager/Media/MediaItemExtensions.cs
+++ b/MediaManager/Media/MediaItemExtensions.cs
@@ -5,7 +5,7 @@
         public static string GetTitle(this IMediaItem mediaItem)
         {
             if (!string.IsNullOrEmpty(mediaItem.DisplayTitle))
-                return mediaItem.Title;
+                return mediaItem.DisplayTitle;
             else if (!string.IsNullOrEmpty(mediaItem.Title))
                 return mediaItem.Title;
             else


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Bug fix

### :arrow_heading_down: What is the current behavior?

Uses `Title` property instead of `DisplayTitle` when `DisplayTitle` has a value.

### :new: What is the new behavior (if this is a feature change)?

Uses `DisplayTitle` property when `DisplayTitle` has a value.

### :boom: Does this PR introduce a breaking change?

It fixes the precedence to use the `DisplayTitle` property when it exists instead of the `Title` property.

### :bug: Recommendations for testing

Specify a `DisplayTitle` that is different than `Title` and see it display now!

### :memo: Links to relevant issues/docs

### :thinking: Checklist before submitting

- [X ] All projects build
- [ X] Follows style guide lines 
- [ ]X Relevant documentation was updated
- [ X] Rebased onto current develop
