### PR TITLE
Fix for bug issue #511 PlaybackController pause dose not retaine the …

### DIFF
--- a/MediaManager/MediaManager.csproj
+++ b/MediaManager/MediaManager.csproj
@@ -98,4 +98,10 @@
     <Compile Include="Platforms\Xamarin\**\*.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Platforms\Uap\Video\VideoView.xaml">
+      <Generator>MSBuild:Compile</Generator>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/MediaManager/Platforms/Android/MediaManagerImplementation.cs
+++ b/MediaManager/Platforms/Android/MediaManagerImplementation.cs
@@ -151,7 +151,8 @@ namespace MediaManager
 
         public override TimeSpan Duration => MediaBrowserManager?.MediaController.Metadata?.ToMediaItem().Duration ?? TimeSpan.Zero;
 
-        public override float Speed {
+        public override float Speed
+        {
             get => MediaBrowserManager?.MediaController.PlaybackState?.PlaybackSpeed ?? 0;
             set => throw new NotImplementedException();
         }
@@ -164,7 +165,7 @@ namespace MediaManager
 
         public override Task Play()
         {
-            if(!this.IsPlaying())
+            if (!this.IsPlaying() && this.State != MediaPlayerState.Paused)
                 MediaBrowserManager.MediaController.GetTransportControls().Prepare();
 
             MediaBrowserManager.MediaController.GetTransportControls().Play();
@@ -274,7 +275,7 @@ namespace MediaManager
 
         public override Task<bool> PlayQueueItem(IMediaItem mediaItem)
         {
-            if(!MediaQueue.Contains(mediaItem))
+            if (!MediaQueue.Contains(mediaItem))
                 return Task.FromResult(false);
 
             MediaBrowserManager.MediaController.GetTransportControls().SkipToQueueItem(MediaQueue.IndexOf(mediaItem));


### PR DESCRIPTION
…duration

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
PlaybackController Play() dose not consider that the state is in paused mode, and try to start new session

### :new: What is the new behavior (if this is a feature change)?
PlaybackController Play() will know that the player is paused and continue from the last duration.

### :boom: Does this PR introduce a breaking change?
There was no major changes. 

### :bug: Recommendations for testing
I only fixed the issue from the android platform, you need to test and implement the fix for other platforms.
I did not do it cuz im not able to test the fix for the other platforms.

### :memo: Links to relevant issues/docs
https://github.com/martijn00/XamarinMediaManager/issues/511
### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
