### PR TITLE
vs2019 build fixes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
         - master
         - /release\/.*/
   version: 1.0.{build}
-  image: Visual Studio 2017
+  image: Visual Studio 2019
   before_build:
   - cmd: dotnet --info
   - cmd: dotnet tool install --tool-path . SignClient
@@ -26,7 +26,7 @@
       only:
         - develop
   version: 1.0.{build}
-  image: Visual Studio 2017
+  image: Visual Studio 2019
   before_build:
   - cmd: dotnet --info
   - cmd: dotnet tool install --tool-path . SignClient

--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 #tool nuget:?package=GitVersion.CommandLine
 #tool nuget:?package=vswhere
 #addin nuget:?package=Cake.Figlet&version=1.1.0
-#addin nuget:?package=Cake.Git&version=0.21.0
+#addin nuget:?package=Cake.Git&version=0.17.0
 #addin nuget:?package=Polly
 
 using Polly;

--- a/build.cake
+++ b/build.cake
@@ -1,8 +1,8 @@
-#tool nuget:?package=GitVersion.CommandLine
-#tool nuget:?package=vswhere
-#addin nuget:?package=Cake.Figlet&version=1.1.0
-#addin nuget:?package=Cake.Git&version=0.17.0
-#addin nuget:?package=Polly
+#tool nuget:?package=GitVersion.CommandLine&version=4.0.0
+#tool nuget:?package=vswhere&version=2.6.7
+#addin nuget:?package=Cake.Figlet&version=1.3.0
+#addin nuget:?package=Cake.Git&version=0.19.0
+#addin nuget:?package=Polly&version=7.1.0
 
 using Polly;
 
@@ -72,7 +72,7 @@ Task("ResolveBuildTools")
     var vsLatest = VSWhereLatest(vsWhereSettings);
     msBuildPath = (vsLatest == null)
         ? null
-        : vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+        : vsLatest.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe");
 
     if (msBuildPath != null)
         Information("Found MSBuild at {0}", msBuildPath.ToString());
@@ -276,7 +276,7 @@ MSBuildSettings GetDefaultBuildSettings()
         ToolPath = msBuildPath,
         Verbosity = verbosity,
         ArgumentCustomization = args => args.Append("/m"),
-        ToolVersion = MSBuildToolVersion.VS2017
+        ToolVersion = MSBuildToolVersion.VS2019
     };
 
     return settings;

--- a/build.cake
+++ b/build.cake
@@ -1,7 +1,7 @@
 #tool nuget:?package=GitVersion.CommandLine
 #tool nuget:?package=vswhere
 #addin nuget:?package=Cake.Figlet&version=1.1.0
-#addin nuget:?package=Cake.Git&version=0.17.0
+#addin nuget:?package=Cake.Git&version=0.21.0
 #addin nuget:?package=Polly
 
 using Polly;

--- a/build.cake
+++ b/build.cake
@@ -70,20 +70,12 @@ Task("ResolveBuildTools")
     };
     
     var vsLatest = VSWhereLatest(vsWhereSettings);
-    if(vsLatest != null)
-    {
-        var tryPath = vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
-        if(FileExists(tryPath))
-            msBuildPath = tryPath;
-        else if(FileExists(tryPath = vsLatest.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe")))
-            msBuildPath = tryPath;
-    }
+    msBuildPath = (vsLatest == null)
+        ? null
+        : vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
 
-    if (FileExists(msBuildPath))
+    if (msBuildPath != null)
         Information("Found MSBuild at {0}", msBuildPath.ToString());
-    else
-        throw new InvalidOperationException("Could not locate MSBuild");
-
 });
 
 Task("Restore")

--- a/build.cake
+++ b/build.cake
@@ -70,12 +70,20 @@ Task("ResolveBuildTools")
     };
     
     var vsLatest = VSWhereLatest(vsWhereSettings);
-    msBuildPath = (vsLatest == null)
-        ? null
-        : vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+    if(vsLatest != null)
+    {
+        var tryPath = vsLatest.CombineWithFilePath("./MSBuild/15.0/Bin/MSBuild.exe");
+        if(FileExists(tryPath))
+            msBuildPath = tryPath;
+        else if(FileExists(tryPath = vsLatest.CombineWithFilePath("./MSBuild/Current/Bin/MSBuild.exe")))
+            msBuildPath = tryPath;
+    }
 
-    if (msBuildPath != null)
+    if (FileExists(msBuildPath))
         Information("Found MSBuild at {0}", msBuildPath.ToString());
+    else
+        throw new InvalidOperationException("Could not locate MSBuild");
+
 });
 
 Task("Restore")


### PR DESCRIPTION
I was not able to build the plugin with only vs2019 installed (no vs2017 also)

* Search for MSBuild in "Current" if not found in "15.0" folder
* Also: Update Cake.Git to v0.21.0
  * My environment didn't like v0.17.0 - maybe this is not universal
 
I still didn't get everything to build in vs2019, but the Cake build succeeded enough to build the plugin 
