### PR TITLE
Allow UWP to play local files given a dos path to media

### DIFF
--- a/MediaManager/Platforms/Uap/Media/MediaItemExtensions.cs
+++ b/MediaManager/Platforms/Uap/Media/MediaItemExtensions.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Threading.Tasks;
 using MediaManager.Media;
 using Windows.Media.Core;
 using Windows.Storage;
@@ -9,27 +8,17 @@ namespace MediaManager.Platforms.Uap.Media
 {
     public static class MediaItemExtensions
     {
-        public static MediaSource ToMediaSource(this IMediaItem mediaItem)
+        public static async Task<MediaSource> ToMediaSource(this IMediaItem mediaItem)
         {
-            /*
+            //TODO: Get Metadata from MediaSource
             switch (mediaItem.MediaLocation)
             {
-                case MediaLocation.Default:
-                case MediaLocation.Remote:
-                    return MediaSource.CreateFromUri(new Uri(mediaItem.MediaUri));
                 case MediaLocation.FileSystem:
-                    var du = Player.SystemMediaTransportControls.DisplayUpdater;
                     var storageFile = await StorageFile.GetFileFromPathAsync(mediaItem.MediaUri);
-
-                    var playbackType = (mediaItem.MediaType == MediaType.Audio ? Windows.Media.MediaPlaybackType.Music : Windows.Media.MediaPlaybackType.Video);
-                    await du.CopyFromFileAsync(playbackType, storageFile);
-                    du.Update();
-
                     return MediaSource.CreateFromStorageFile(storageFile);
-            }*/
-
-            //TODO: Get Metadata from MediaSource
-            return MediaSource.CreateFromUri(new Uri(mediaItem.MediaUri));
+                default:
+                    return MediaSource.CreateFromUri(new Uri(mediaItem.MediaUri));
+            }
         }
     }
 }

--- a/MediaManager/Platforms/Uap/Player/WindowsMediaPlayer.cs
+++ b/MediaManager/Platforms/Uap/Player/WindowsMediaPlayer.cs
@@ -114,7 +114,7 @@ namespace MediaManager.Platforms.Uap.Media
         {
             BeforePlaying?.Invoke(this, new MediaPlayerEventArgs(mediaItem, this));
 
-            var item = new MediaPlaybackItem(mediaItem.ToMediaSource());
+            var item = new MediaPlaybackItem(await mediaItem.ToMediaSource());
 
             //TODO: Fill MediaPlaybackList with full queue
             MediaPlaybackList.Items.Clear();


### PR DESCRIPTION
### :sparkles: UWP can now play local files

### :arrow_heading_down: UWP cannot play a file with local path, e.g. "C:\Users\me\Music\achy-breaky-heart.mp3"

### :new: UWP can play a file with local path, e.g. "C:\Users\me\Music\achy-breaky-heart.mp3"


### :boom: Paths like "http:..." still work on UWP

### :bug: Testing suggestions: Check local, remote, resource paths play


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [-] All projects build
  - I couldn't get the whole project to build before.  See https://github.com/martijn00/XamarinMediaManager/pull/531
- [-] Follows style guide lines
 - Need a link to this.
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
