### PR TITLE
Pass whole playlist to UWP and start playing from the selected item

### DIFF
--- a/MediaManager/Platforms/Uap/Player/WindowsMediaPlayer.cs
+++ b/MediaManager/Platforms/Uap/Player/WindowsMediaPlayer.cs
@@ -116,13 +116,17 @@ namespace MediaManager.Platforms.Uap.Media
         {
             BeforePlaying?.Invoke(this, new MediaPlayerEventArgs(mediaItem, this));
 
-            var item = new MediaPlaybackItem(await mediaItem.ToMediaSource());
-
-            //TODO: Fill MediaPlaybackList with full queue
             MediaPlaybackList.Items.Clear();
-            MediaPlaybackList.Items.Add(item);
+            foreach (var mediaQueueItem in MediaManager.MediaQueue)
+            {
+                var mediaPlaybackItem = new MediaPlaybackItem(await mediaQueueItem.ToMediaSource());
+                MediaPlaybackList.Items.Add(mediaPlaybackItem);
+                if (mediaQueueItem == mediaItem)
+                {
+                    MediaPlaybackList.StartingItem = mediaPlaybackItem;
+                }
+            }
             Player.Source = MediaPlaybackList;
-
             await Play();
 
             AfterPlaying?.Invoke(this, new MediaPlayerEventArgs(mediaItem, this));


### PR DESCRIPTION
### :sparkles: Fixes issue #533


### :arrow_heading_down: When you attempt to play a playlist on UWP, only the first item plays.


### :new: The whole playlist is played on UWP.  It starts playing from the requested item.


### :boom: This should not be a breaking change


### :bug:
* Try playing a playlist from the first item
* Try playing a playlist from the seconds item


### :memo: 
* https://github.com/martijn00/XamarinMediaManager/issues/533


### :thinking: Checklist before submitting

- [ ] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
