### PR TITLE
Detach player for play audio in background and fix 2nd play on iOS

### DIFF
--- a/MediaManager/Platforms/Ios/Video/PlayerViewController.cs
+++ b/MediaManager/Platforms/Ios/Video/PlayerViewController.cs
@@ -1,0 +1,14 @@
+﻿using AVKit;
+
+namespace MediaManager.Platforms.Ios.Video
+{
+    public class PlayerViewController : AVPlayerViewController
+    {
+        public override void ViewWillDisappear(bool animated)
+        {
+            base.ViewWillDisappear(animated);
+
+            Player = null;
+        }
+    }
+}

--- a/MediaManager/Platforms/Ios/Video/VideoView.cs
+++ b/MediaManager/Platforms/Ios/Video/VideoView.cs
@@ -21,7 +21,7 @@ namespace MediaManager.Platforms.Ios.Video
             {
                 if(_playerViewController == null)
                 {
-                    PlayerViewController = new AVPlayerViewController();
+                    PlayerViewController = new PlayerViewController();
                 }
                 return _playerViewController;
             }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
bug fix

### :arrow_heading_down: What is the current behavior?
Video hung-up on the 2nd play

### :new: What is the new behavior (if this is a feature change)?
The player is detached on leaving the player view to continue playing in the background and restart video correctly.

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#534

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
