### PR TITLE
Remove MediaItemToPlay parameter from ViewModel

### DIFF
--- a/Samples/ElementPlayer.Core/ViewModels/HomeViewModel.cs
+++ b/Samples/ElementPlayer.Core/ViewModels/HomeViewModel.cs
@@ -68,7 +68,7 @@ namespace ElementPlayer.Core.ViewModels
         {
             MediaManager.MediaQueue.Clear();
 
-            await this.NavigationService.Navigate<PlayerViewModel, IMediaItem>(mediaItem);
+            await this.NavigationService.Navigate<PlayerViewModel>();
 
             await MediaManager.Play(mediaItem);
 

--- a/Samples/ElementPlayer.Core/ViewModels/MiniPlayerViewModel.cs
+++ b/Samples/ElementPlayer.Core/ViewModels/MiniPlayerViewModel.cs
@@ -8,7 +8,7 @@ using MvvmCross.Navigation;
 
 namespace ElementPlayer.Core.ViewModels
 {
-    public class MiniPlayerViewModel : BaseViewModel<IMediaItem>
+    public class MiniPlayerViewModel : BaseViewModel
     {
         public readonly IMediaManager MediaManager;
 
@@ -18,13 +18,6 @@ namespace ElementPlayer.Core.ViewModels
             PlayPauseCommand = new MvxAsyncCommand(MediaManager.PlayPause);
 
             MediaManager.PositionChanged += Current_PositionChanged;
-        }
-
-        public IMediaItem MediaItemToPlay;
-
-        public override void Prepare(IMediaItem mediaItem)
-        {
-            MediaItemToPlay = mediaItem;
         }
 
         public override string Title => "Player";

--- a/Samples/ElementPlayer.Core/ViewModels/PlayerViewModel.cs
+++ b/Samples/ElementPlayer.Core/ViewModels/PlayerViewModel.cs
@@ -8,7 +8,7 @@ using MvvmCross.Navigation;
 
 namespace ElementPlayer.Core.ViewModels
 {
-    public class PlayerViewModel : BaseViewModel<IMediaItem>
+    public class PlayerViewModel : BaseViewModel
     {
         public PlayerViewModel(IMvxLogProvider logProvider, IMvxNavigationService navigationService, IMediaManager mediaManager) : base(logProvider, navigationService)
         {
@@ -24,13 +24,6 @@ namespace ElementPlayer.Core.ViewModels
 
             MediaManager.PositionChanged += Current_PositionChanged;
             mediaManager.StateChanged += MediaManager_StateChanged;
-        }
-
-        public IMediaItem MediaItemToPlay;
-
-        public override void Prepare(IMediaItem mediaItem)
-        {
-            MediaItemToPlay = mediaItem;
         }
 
         public override string Title => "Player";

--- a/Samples/ElementPlayer.iOS/Views/PlayerViewController.cs
+++ b/Samples/ElementPlayer.iOS/Views/PlayerViewController.cs
@@ -22,7 +22,6 @@ namespace ElementPlayer.iOS.Views
             CrossMediaManager.Current.Init();
 
             CrossMediaManager.Current.MediaPlayer.VideoView = vwPlayer;
-            CrossMediaManager.Current.Play(ViewModel.MediaItemToPlay);
 
             var set = this.CreateBindingSet<PlayerViewController, PlayerViewModel>();
             set.Bind(progressPlayer).To(vm => vm.FloatedPosition);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
fix

### :arrow_heading_down: What is the current behavior?
Play is called twice in example project on native ios in PlayerViewController

### :new: What is the new behavior (if this is a feature change)?
Play is called only from Manager in the example project

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
