### PR TITLE
Fix for string source in VideoView in Xamarin.Forms

### DIFF
--- a/MediaManager.Forms/VideoView.cs
+++ b/MediaManager.Forms/VideoView.cs
@@ -28,12 +28,16 @@ namespace MediaManager.Forms
             if (Source is string url)
             {
                 if (url != e.MediaItem.MediaUri)
+                {
                     Source = e.MediaItem.MediaUri;
+                }
             }
             else if (Source is IMediaItem)
             {
                 if (Source != e.MediaItem)
+                {
                     Source = e.MediaItem;
+                }
             }
         }
 

--- a/MediaManager.Forms/VideoView.cs
+++ b/MediaManager.Forms/VideoView.cs
@@ -25,8 +25,16 @@ namespace MediaManager.Forms
 
         private void MediaManager_MediaItemChanged(object sender, MediaItemEventArgs e)
         {
-            if (Source != e.MediaItem)
-                Source = e.MediaItem;
+            if (Source is string url)
+            {
+                if (url != e.MediaItem.MediaUri)
+                    Source = e.MediaItem.MediaUri;
+            }
+            else if (Source is IMediaItem)
+            {
+                if (Source != e.MediaItem)
+                    Source = e.MediaItem;
+            }
         }
 
         private void MediaManager_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
fix

### :arrow_heading_down: What is the current behavior?
VideoView is not working correctly when the source is a string in Xamarin.Forms

### :new: What is the new behavior (if this is a feature change)?
VideoView is working correctly when the source is a string in Xamarin.Forms

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
