### PR TITLE
MediaItemChanged is fired directly on PlayNext in AppleMediaManager

### DIFF
--- a/MediaManager/Platforms/Apple/AppleMediaManagerBase.cs
+++ b/MediaManager/Platforms/Apple/AppleMediaManagerBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading.Tasks;
 using AVFoundation;
 using MediaManager.Media;
 using MediaManager.Notifications;
@@ -16,6 +17,17 @@ namespace MediaManager
     {
         public AppleMediaManagerBase()
         {
+        }
+
+        public override async Task<bool> PlayNext()
+        {
+            var result = await base.PlayNext();
+            if (result) 
+            {
+                OnMediaItemChanged(this, new MediaItemEventArgs(MediaQueue.Current));
+            }
+
+            return result;
         }
 
         private IMediaPlayer _mediaPlayer;

--- a/MediaManager/Platforms/Apple/AppleMediaManagerBase.cs
+++ b/MediaManager/Platforms/Apple/AppleMediaManagerBase.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Threading.Tasks;
 using AVFoundation;
 using MediaManager.Media;
 using MediaManager.Notifications;
@@ -17,17 +16,6 @@ namespace MediaManager
     {
         public AppleMediaManagerBase()
         {
-        }
-
-        public override async Task<bool> PlayNext()
-        {
-            var result = await base.PlayNext();
-            if (result) 
-            {
-                OnMediaItemChanged(this, new MediaItemEventArgs(MediaQueue.Current));
-            }
-
-            return result;
         }
 
         private IMediaPlayer _mediaPlayer;

--- a/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
+++ b/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
@@ -155,9 +155,7 @@ namespace MediaManager.Platforms.Apple.Player
 
             //TODO: Android has its own queue and goes to next. Maybe use native apple queue
             var succesfullNext = await MediaManager.PlayNext();
-            if (succesfullNext)
-                MediaManager.OnMediaItemChanged(this, new MediaItemEventArgs(MediaManager.MediaQueue.Current));
-            else
+            if (!succesfullNext)
                 await Stop();
         }
 

--- a/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
+++ b/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
@@ -173,6 +173,7 @@ namespace MediaManager.Platforms.Apple.Player
 
             Player.ActionAtItemEnd = AVPlayerActionAtItemEnd.None;
             Player.ReplaceCurrentItemWithPlayerItem(item);
+            MediaManager.OnMediaItemChanged(this, new MediaItemEventArgs(mediaItem));
             await Play();
 
             AfterPlaying?.Invoke(this, new MediaPlayerEventArgs(mediaItem, this));


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix

### :arrow_heading_down: What is the current behavior?
MediaItemChanged is not fired on PlayNext on iOS

### :new: What is the new behavior (if this is a feature change)?
MediaItemChanged is fired on successful PlayNext on iOS

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#544 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
