### PR TITLE
Seek based on TotalMilliseconds, not ms component.

### DIFF
--- a/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
+++ b/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
@@ -280,7 +280,7 @@ namespace MediaManager.Platforms.Android.Player
 
         public Task SeekTo(TimeSpan position)
         {
-            Player.SeekTo(position.Milliseconds);
+            Player.SeekTo((long)position.TotalMilliseconds);
             return Task.CompletedTask;
         }
 


### PR DESCRIPTION
The `Milliseconds` property of a `TimeSpan` is just the milliseconds component (i.e., the fractional part of the second component).

This change uses the `TotalMilliseconds` property, which is the **total** milliseconds in a `TimeSpan` (and casts the value to a `long`, since it is a `double`).