### PR TITLE
Prevent to fire MediaItemChanged more than once

### DIFF
--- a/MediaManager/MediaManagerBase.cs
+++ b/MediaManager/MediaManagerBase.cs
@@ -308,8 +308,14 @@ namespace MediaManager
         public event MediaItemChangedEventHandler MediaItemChanged;
         public event MediaItemFailedEventHandler MediaItemFailed;
 
+        protected IMediaItem _currentSource;
+
         internal void OnBufferedChanged(object sender, BufferedChangedEventArgs e) => BufferedChanged?.Invoke(sender, e);
-        internal void OnMediaItemChanged(object sender, MediaItemEventArgs e) => MediaItemChanged?.Invoke(sender, e);
+        internal void OnMediaItemChanged(object sender, MediaItemEventArgs e)
+        {
+            if (SetProperty(ref _currentSource, e.MediaItem))
+                MediaItemChanged?.Invoke(sender, e);
+        }
         internal void OnMediaItemFailed(object sender, MediaItemFailedEventArgs e) => MediaItemFailed?.Invoke(sender, e);
         internal void OnMediaItemFinished(object sender, MediaItemEventArgs e) => MediaItemFinished?.Invoke(sender, e);
         internal void OnPositionChanged(object sender, PositionChangedEventArgs e) => PositionChanged?.Invoke(sender, e);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
fix

### :arrow_heading_down: What is the current behavior?
MediaItemChanged is firing multiple times for every media item

### :new: What is the new behavior (if this is a feature change)?
MediaItemChanged is firing only once for every media item

### :boom: Does this PR introduce a breaking change?
no

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#501 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
