### PR TITLE
[iOS] RepeatMode.Off fix

### DIFF
--- a/MediaManager/Platforms/Apple/AppleMediaManagerBase.cs
+++ b/MediaManager/Platforms/Apple/AppleMediaManagerBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using AVFoundation;
 using MediaManager.Media;
 using MediaManager.Notifications;
@@ -8,6 +9,7 @@ using MediaManager.Platforms.Apple.Player;
 using MediaManager.Platforms.Apple.Volume;
 using MediaManager.Playback;
 using MediaManager.Player;
+using MediaManager.Queue;
 using MediaManager.Volume;
 
 namespace MediaManager
@@ -118,28 +120,26 @@ namespace MediaManager
             }
         }
 
-        private AVPlayerLooper _looper;
         public override RepeatMode RepeatMode
         {
-            get
-            {
-                return _looper != null ? RepeatMode.One : RepeatMode.All;
-            }
+            get => AppleMediaPlayer.RepeatMode;
             set
             {
-                switch (value)
+                AppleMediaPlayer.RepeatMode = value;
+                OnPropertyChanged(nameof(RepeatMode));
+            }
+        }
+
+        public override ShuffleMode ShuffleMode
+        {
+            get => base.ShuffleMode;
+            set
+            {
+                if (base.ShuffleMode != value)
                 {
-                    case RepeatMode.Off:
-                        _looper = null;
-                        break;
-                    case RepeatMode.One:
-                    case RepeatMode.All:
-                        _looper = AVPlayerLooper.FromPlayer(Player, Player.CurrentItem);
-                        break;
-                    default:
-                        break;
+                    base.ShuffleMode = value;
+                    OnPropertyChanged(nameof(ShuffleMode));
                 }
-                //MediaPlayer.RepeatMode = value;
             }
         }
     }

--- a/MediaManager/Platforms/Apple/AppleMediaManagerBase.cs
+++ b/MediaManager/Platforms/Apple/AppleMediaManagerBase.cs
@@ -125,8 +125,11 @@ namespace MediaManager
             get => AppleMediaPlayer.RepeatMode;
             set
             {
-                AppleMediaPlayer.RepeatMode = value;
-                OnPropertyChanged(nameof(RepeatMode));
+                if (AppleMediaPlayer.RepeatMode != value)
+                {
+                    AppleMediaPlayer.RepeatMode = value;
+                    OnPropertyChanged(nameof(RepeatMode));
+                }
             }
         }
 

--- a/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
+++ b/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
@@ -8,6 +8,7 @@ using Foundation;
 using MediaManager.Library;
 using MediaManager.Media;
 using MediaManager.Platforms.Apple.Playback;
+using MediaManager.Playback;
 using MediaManager.Player;
 
 namespace MediaManager.Platforms.Apple.Player
@@ -34,6 +35,17 @@ namespace MediaManager.Platforms.Apple.Player
                 _player = value;
             }
         }
+
+        #region RepeatMode
+
+        private RepeatMode _repeatMode;
+        public virtual RepeatMode RepeatMode
+        {
+            get => _repeatMode;
+            set => SetProperty(ref _repeatMode, value);
+        }
+
+        #endregion
 
         private NSObject didFinishPlayingObserver;
         private NSObject itemFailedToPlayToEndTimeObserver;
@@ -157,7 +169,19 @@ namespace MediaManager.Platforms.Apple.Player
             //TODO: Android has its own queue and goes to next. Maybe use native apple queue
             var succesfullNext = await MediaManager.PlayNext();
             if (!succesfullNext)
+            {
                 await Stop();
+            }
+            else if (RepeatMode == RepeatMode.All && MediaManager.MediaQueue.Any())
+            {
+                MediaManager.MediaQueue.CurrentIndex = 0;
+                await MediaManager.PlayQueueItem(MediaManager.MediaQueue.Current);
+            }
+            else if (RepeatMode == RepeatMode.One && MediaManager.MediaQueue.Any())
+            {
+                MediaManager.MediaQueue.CurrentIndex = MediaManager.MediaQueue.CurrentIndex - 1;
+                await MediaManager.PlayQueueItem(MediaManager.MediaQueue.Current);
+            }
         }
 
         public override Task Pause()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix for iOS part of report #576 

### :arrow_heading_down: What is the current behavior?
Currently we are not able to turn off repeat all on iOS.

### :new: What is the new behavior (if this is a feature change)?
It is possible to turn off repeating.

### :boom: Does this PR introduce a breaking change?
Nope.

### :bug: Recommendations for testing


### :memo: Links to relevant issues/docs
#576 

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [x] Relevant documentation was updated
- [x] Rebased onto current develop
