### PR TITLE
[iOS] - Improved Precision on SeekTo for iOS

### DIFF
--- a/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
+++ b/MediaManager/Platforms/Apple/Player/AppleMediaPlayer.cs
@@ -186,7 +186,7 @@ namespace MediaManager.Platforms.Apple.Player
 
         public override async Task SeekTo(TimeSpan position)
         {
-            await Player.SeekAsync(CMTime.FromSeconds(position.TotalSeconds, 1));
+            await Player.SeekAsync(CMTime.FromSeconds(position.TotalSeconds, Player.CurrentItem.Duration.TimeScale), CMTime.Zero, CMTime.Zero);
         }
 
         public override async Task Stop()


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
This is an enhancement on the SeekTo method for iOS, which didn't have enough precision and would seek to the desired time with a difference of ~500ms.

### :arrow_heading_down: What is the current behavior?
The precision of the SeekTo method was small, and the position is of by ~500ms.


### :new: What is the new behavior (if this is a feature change)?
This change uses the current media item's timescale to navigate correctly to the desired position.

### :bug: Recommendations for testing
Use the SeekTo method by passing milliseconds on the timespan on iOS, and check that the position is the desired or at least the error difference is really small.


### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
