### PR TITLE
Updated the Xamarin Blog link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ More documenatation and information is available on the [Wiki](https://github.co
 
 # Blogs
 
-* [Xamarin Blog](https://blog.xamarin.com/play-audio-and-video-with-the-mediamanager-plugin-for-xamarin/)
+* [Xamarin Blog](https://devblogs.microsoft.com/xamarin/play-audio-and-video-with-the-mediamanager-plugin-for-xamarin/)
 * [Baseflow Blog](https://baseflow.com/blogs/mobile-video-matters/)
 
 ## Installation


### PR DESCRIPTION
Xamarin.com blog has been fully migrated to devblogs.microsoft.com and there's no redirect from the old articles to the new system. I updated the link to point to the correct location.

### :sparkles: What kind of change does this PR introduce? 
Docs update


### :arrow_heading_down: What is the current behavior? 
Xamarin Blog link redirects to the main Xamarin blog on devblogs.microsoft.com

### :new: What is the new behavior (if this is a feature change)?
Xamarin Blog link goes directly to the correct article

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Click the link :)

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
