### PR TITLE
Update MediaBrowserService.cs

### DIFF
--- a/MediaManager/Platforms/Android/MediaSession/MediaBrowserService.cs
+++ b/MediaManager/Platforms/Android/MediaSession/MediaBrowserService.cs
@@ -141,7 +141,14 @@ namespace MediaManager.Platforms.Android.MediaSession
                     if (ongoing && !IsForeground)
                     {
                         ContextCompat.StartForegroundService(ApplicationContext, new Intent(ApplicationContext, MediaBrowserManager.ServiceType));
-                        StartForeground(notificationId, notification, ForegroundService.TypeMediaPlayback);
+                        if (Build.VERSION.SdkInt >= BuildVersionCodes.S)
+                        {
+                            StartForeground(notificationId, notification, ForegroundService.TypeMediaPlayback);
+                        }
+                        else
+                        {
+                            StartForeground(notificationId, notification);
+                        }
                         IsForeground = true;
                     }
                 }


### PR DESCRIPTION


### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
It is a bugfix related to Android MediaBrowserService which causes an instant crash when starting the foreground process on Android Pie and maybe others too.

### :arrow_heading_down: What is the current behavior?
The application crashes as soon as trying to create a notification on some systems.

### :new: What is the new behavior (if this is a feature change)?
We don't use ForegroundService.TypeMediaPlayback when starting foreground service as it may not be known by earlier operating systems like Android Pie.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
#894 

### :memo: Links to relevant issues/docs
-

### :thinking: Checklist before submitting
- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
