### PR TITLE
Fix for bug #703 - Repeat queue items does not work on android

### DIFF
--- a/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
+++ b/MediaManager/Platforms/Android/Player/AndroidMediaPlayer.cs
@@ -190,7 +190,12 @@ namespace MediaManager.Platforms.Android.Player
                     {
                         case Com.Google.Android.Exoplayer2.Player.StateEnded:
                             if (!Player.HasNext)
+                            {
                                 MediaManager.OnMediaItemFinished(this, new MediaItemEventArgs(MediaManager.Queue.Current));
+                                // Fix for bug #703 - Repeat queue items does not work on android
+                                // https://github.com/Baseflow/XamarinMediaManager/issues/703
+                                MediaManager.PlayNext();
+                            }
                             //TODO: This means the whole list is finished. Should we fire an event?
                             break;
                         case Com.Google.Android.Exoplayer2.Player.StateIdle:


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Repeat queue items does not work on android

### :arrow_heading_down: What is the current behavior?
Repeat queue items does not work on android though repeat mode is set to All or One

### :new: What is the new behavior (if this is a feature change)?
Next item is played at the end of the media queue. MediaManager.PlayNext method picks up the first item and starts playing it.

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
Play multiple items. If the repeat mode is set to All, when player finishes with last song, it should resume with the first song in queue.

### :memo: Links to relevant issues/docs
#703 
https://github.com/Baseflow/XamarinMediaManager/issues/703

