### PR TITLE
Adds step to prepare() when calling PlayQueueItem

### DIFF
--- a/MediaManager.Forms/MediaManager.Forms.csproj
+++ b/MediaManager.Forms/MediaManager.Forms.csproj
@@ -34,7 +34,7 @@
     <!--<Page Include="Platforms\Uap\**\*.xaml" SubType="Designer" Generator="MSBuild:Compile" />-->
     <None Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
     <Compile Update="**\*.xaml.cs" DependentUpon="%(Filename)" />
-    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.755" />
+    <PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.756" />
     <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221209.1" />
   </ItemGroup>
 

--- a/MediaManager/Platforms/Android/MediaManagerImplementation.cs
+++ b/MediaManager/Platforms/Android/MediaManagerImplementation.cs
@@ -299,6 +299,9 @@ namespace MediaManager
 
             Queue.CurrentIndex = Queue.IndexOf(mediaItem);
 
+            if (this.IsStopped())
+                MediaController.GetTransportControls().Prepare();
+
             MediaController.GetTransportControls().SkipToQueueItem(Queue.IndexOf(mediaItem));
             return true;
         }

--- a/MediaManager/Platforms/Android/MediaManagerImplementation.cs
+++ b/MediaManager/Platforms/Android/MediaManagerImplementation.cs
@@ -290,20 +290,9 @@ namespace MediaManager
             return false;
         }
 
-        public override async Task<bool> PlayQueueItem(IMediaItem mediaItem)
+        public override Task<bool> PlayQueueItem(IMediaItem mediaItem)
         {
-            await EnsureInit();
-
-            if (mediaItem == null || !Queue.Contains(mediaItem))
-                return false;
-
-            Queue.CurrentIndex = Queue.IndexOf(mediaItem);
-
-            if (this.IsStopped())
-                MediaController.GetTransportControls().Prepare();
-
-            MediaController.GetTransportControls().SkipToQueueItem(Queue.IndexOf(mediaItem));
-            return true;
+            return PlayQueueItem(Queue.IndexOf(mediaItem));
         }
 
         public override async Task<bool> PlayQueueItem(int index)
@@ -315,6 +304,9 @@ namespace MediaManager
                 return false;
 
             Queue.CurrentIndex = index;
+
+            if (this.IsStopped())
+                MediaController.GetTransportControls().Prepare();
 
             MediaController.GetTransportControls().SkipToQueueItem(index);
             return true;


### PR DESCRIPTION
Upgrading Windows SDK version to address version downgrade

### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix. 

### :arrow_heading_down: What is the current behavior?
When starting a queue from PlayQueueItem, the media plays, but when play is subsequently called, it restarts the queue

### :new: What is the new behavior (if this is a feature change)?
Calling pause and play now behave appropriate after starting a queue with PlayQueueItem

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Test using an app the loads a queue then starts any item with PlayQueueItem.

### :memo: Links to relevant issues/docs
https://github.com/Baseflow/XamarinMediaManager/issues/856

### :thinking: Checklist before submitting

- [ X ] All projects build
- [ X ] Follows style guide lines 
- [ X ] Relevant documentation was updated
- [ X ] Rebased onto current develop
