### PR TITLE
Added MixWithOthers to audio session init for iOS

### DIFF
--- a/MediaManager/Platforms/Ios/Player/IosMediaPlayer.cs
+++ b/MediaManager/Platforms/Ios/Player/IosMediaPlayer.cs
@@ -102,7 +102,7 @@ namespace MediaManager.Platforms.Ios.Player
             var audioSession = AVAudioSession.SharedInstance();
             try
             {
-                audioSession.SetCategory(AVAudioSession.CategoryPlayback);
+                audioSession.SetCategory(AVAudioSessionCategoryOptions.Playback, AVAudioSessionCategoryOptions.MixWithOthers);
                 audioSession.SetActive(true, out var activationError);
                 if (activationError != null)
                     Console.WriteLine("Could not activate audio session {0}", activationError.LocalizedDescription);


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Bug fix.

### :arrow_heading_down: What is the current behavior?
When an iOS cold-launches with this NuGet installed, it ducks/pauses the audio of any other application running in the background.

### :new: What is the new behavior (if this is a feature change)?
When an app cold-launches with this NuGet installed, it will instead mix it's audio with that of other apps in the background rather than forcing them to duck or pause.

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Use the Apple Music app to play one of it's, "Radio", streams for free. Background Apple Music and then cold launch an app with this NuGet installed and confirm the Apple Music app does not pause.

### :memo: Links to relevant issues/docs
https://github.com/Baseflow/XamarinMediaManager/issues/816

### :thinking: Checklist before submitting

- [X] All projects build
- [X] Follows style guide lines 
- [X] Relevant documentation was updated
- [X] Rebased onto current develop
